### PR TITLE
fix: HttpMonitor connection lifetime and body cap (#20); drop SQLite Cache=Shared (#21)

### DIFF
--- a/src/cs/Deucalion.Network/Deucalion.Network.csproj
+++ b/src/cs/Deucalion.Network/Deucalion.Network.csproj
@@ -8,7 +8,10 @@
 
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.8.0" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Deucalion.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/cs/Deucalion.Network/Monitors/HttpMonitor.cs
+++ b/src/cs/Deucalion.Network/Monitors/HttpMonitor.cs
@@ -11,11 +11,34 @@ namespace Deucalion.Network.Monitors;
 public class HttpMonitor : PullMonitor
 {
     // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines#recommended-use
-    private static readonly HttpClient CachedHttpClient = new();
-    private static readonly HttpClient CachedHttpClientIgnoreCertificate = new(new HttpClientHandler()
+    //
+    // Process-lifetime clients over SocketsHttpHandler with a bounded PooledConnectionLifetime.
+    // The default lifetime is infinite, so a pooled connection is never re-resolved: a daemon
+    // that runs for months would keep reporting Up against an IP decommissioned at failover --
+    // the exact failure a monitor exists to catch (#20).
+    private static readonly SocketsHttpHandler CachedHandler = CreateHandler(ignoreCertificateErrors: false);
+    private static readonly SocketsHttpHandler CachedHandlerIgnoreCertificate = CreateHandler(ignoreCertificateErrors: true);
+
+    private static readonly HttpClient CachedHttpClient = new(CachedHandler);
+    private static readonly HttpClient CachedHttpClientIgnoreCertificate = new(CachedHandlerIgnoreCertificate);
+
+    /// <summary>Exposed for tests only.</summary>
+    internal static IReadOnlyList<SocketsHttpHandler> CachedHandlers { get; } = [CachedHandler, CachedHandlerIgnoreCertificate];
+
+    private static SocketsHttpHandler CreateHandler(bool ignoreCertificateErrors)
     {
-        ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-    });
+        var handler = new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+        };
+
+        if (ignoreCertificateErrors)
+        {
+            handler.SslOptions.RemoteCertificateValidationCallback = static (_, _, _, _) => true;
+        }
+
+        return handler;
+    }
 
     private const int MaxResponseBodySize = 1024 * 1024; // 1 MB
 
@@ -60,19 +83,17 @@ public class HttpMonitor : PullMonitor
         var stopwatch = Stopwatch.StartNew();
         try
         {
-            // Use HttpCompletionOption.ResponseContentRead if we expect a response body.
-            // Otherwise use ResponseHeadersRead to avoid reading the body unnecessarily.
-            // https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet
-            var completionOption = ExpectedResponseBodyPattern is not null
-                ? HttpCompletionOption.ResponseContentRead
-                : HttpCompletionOption.ResponseHeadersRead;
-
             // Use the appropriate HttpClient based on whether we ignore certificate errors or not.
             var httpClient = IgnoreCertificateErrors ?? false
                 ? CachedHttpClientIgnoreCertificate
                 : CachedHttpClient;
 
-            using var response = await httpClient.SendAsync(request, completionOption, timeoutCts.Token);
+            // Always ResponseHeadersRead, even when a body pattern is set. ResponseContentRead
+            // buffered the entire body inside SendAsync -- up to MaxResponseContentBufferSize,
+            // 2 GB by default -- before the 1 MB cap below was ever applied, so a monitor pointed
+            // at a log dump paid the whole allocation (#20). The body is streamed and capped below.
+            // https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet
+            using var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, timeoutCts.Token);
 
             // Freezes stopwatch.Elapsed
             stopwatch.Stop();

--- a/src/cs/Deucalion.Storage/SqliteStorage.cs
+++ b/src/cs/Deucalion.Storage/SqliteStorage.cs
@@ -16,8 +16,12 @@ public sealed class SqliteStorage : IStorage, IDisposable
         Directory.CreateDirectory(dbPath);
 
         _dbFile = Path.Combine(dbPath, "deucalion.sqlite.db"); // Store the full path
-        // Enable connection pooling (Cache=Shared) and WAL mode for better concurrency
-        _connectionString = $"Data Source={_dbFile};Mode=ReadWriteCreate;Cache=Shared";
+        // Microsoft.Data.Sqlite pools connections by default (Pooling=True), and InitializeAsync
+        // switches the database to WAL. Do not add Cache=Shared: it is SQLite shared-cache mode,
+        // not pooling, and it replaces WAL's file-level locking with in-process table locks that
+        // serialise readers against the writer and can raise SQLITE_LOCKED, which busy_timeout
+        // does not retry (#21).
+        _connectionString = $"Data Source={_dbFile};Mode=ReadWriteCreate";
     }
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)

--- a/src/cs/Deucalion.Tests/Network/HttpMonitorTests.cs
+++ b/src/cs/Deucalion.Tests/Network/HttpMonitorTests.cs
@@ -176,4 +176,88 @@ public class HttpMonitorTests
 
         Assert.Equal(MonitorState.Warn, result.State);
     }
+
+    [Fact]
+    public async Task Issue20_BodyPattern_DoesNotBufferTheWholeResponseBeforeMatching()
+    {
+        // Regression for #20: with HttpCompletionOption.ResponseContentRead the whole body was
+        // buffered inside SendAsync before the 1 MB cap was applied. A server that streams past
+        // the cap and then never completes the response made the monitor time out, even though
+        // the pattern was already in the first kilobyte. With ResponseHeadersRead the monitor reads
+        // its 1 MB, matches, and returns -- the cap is real.
+        var chunk = new string('x', 64 * 1024);
+        await using var server = await TestHttpServer.StartAsync(async context =>
+        {
+            context.Response.ContentType = "text/plain; charset=utf-8";
+            await context.Response.WriteAsync("needle-at-the-start ", context.RequestAborted);
+            for (var i = 0; i < 32; i++) // 2 MB, well past the cap
+            {
+                await context.Response.WriteAsync(chunk, context.RequestAborted);
+                await context.Response.Body.FlushAsync(context.RequestAborted);
+            }
+
+            // Never finish: a full-content read can only end by timeout.
+            await Task.Delay(Timeout.InfiniteTimeSpan, context.RequestAborted);
+        });
+
+        HttpMonitor monitor = new()
+        {
+            Url = server.Url,
+            ExpectedResponseBodyPattern = "needle-at-the-start",
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+
+        var result = await monitor.QueryAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(MonitorState.Up, result.State);
+    }
+
+    [Fact]
+    public async Task BodyPattern_BeyondTheOneMegabyteCap_IsNotSeen()
+    {
+        // Documents the cap: only the first 1 MB is inspected, so a needle after it is a miss.
+        var chunk = new string('x', 64 * 1024);
+        await using var server = await TestHttpServer.StartAsync(async context =>
+        {
+            context.Response.ContentType = "text/plain; charset=utf-8";
+            for (var i = 0; i < 48; i++) // 3 MB
+            {
+                await context.Response.WriteAsync(chunk, context.RequestAborted);
+            }
+            await context.Response.WriteAsync("needle-at-the-end", context.RequestAborted);
+        });
+
+        HttpMonitor monitor = new()
+        {
+            Url = server.Url,
+            ExpectedResponseBodyPattern = "needle-at-the-end",
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+
+        var result = await monitor.QueryAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(MonitorState.Down, result.State);
+        Assert.StartsWith("Unexpected response:", result.ResponseText);
+    }
+
+    [Fact]
+    public void Issue20_CachedClients_RecyclePooledConnections()
+    {
+        // Regression for #20: the default handler's PooledConnectionLifetime is infinite, so a
+        // daemon running for months never re-resolves DNS and keeps probing a decommissioned IP.
+        foreach (var handler in HttpMonitor.CachedHandlers)
+        {
+            Assert.NotEqual(Timeout.InfiniteTimeSpan, handler.PooledConnectionLifetime);
+            Assert.InRange(handler.PooledConnectionLifetime, TimeSpan.FromSeconds(1), TimeSpan.FromMinutes(5));
+        }
+    }
+
+    [Fact]
+    public void IgnoreCertificateErrors_HandlerAcceptsAnyCertificate()
+    {
+        var handler = HttpMonitor.CachedHandlers.Single(h => h.SslOptions.RemoteCertificateValidationCallback is not null);
+
+        Assert.True(handler.SslOptions.RemoteCertificateValidationCallback!(
+            this, certificate: null, chain: null, System.Net.Security.SslPolicyErrors.RemoteCertificateChainErrors));
+    }
 }

--- a/src/cs/Deucalion.Tests/Storage/SqliteStorageConcurrencyTests.cs
+++ b/src/cs/Deucalion.Tests/Storage/SqliteStorageConcurrencyTests.cs
@@ -1,0 +1,74 @@
+using Deucalion.Storage;
+using Xunit;
+
+namespace Deucalion.Tests.Storage;
+
+/// <summary>
+/// Regression for #21: the connection string used Cache=Shared (SQLite shared-cache mode, not
+/// ADO.NET pooling as its comment claimed). Shared cache replaces WAL's file locking with
+/// in-process table locks, and can surface SQLITE_LOCKED under concurrent read + write load.
+/// This is the load the daemon actually runs: the engine writes events while the API and SSE
+/// clients read stats, and the purge service deletes.
+/// </summary>
+public class SqliteStorageConcurrencyTests : SqliteStorageTestBase
+{
+    [Fact]
+    public async Task Issue21_ConcurrentWritesReadsAndPurges_DoNotThrow()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        const int writers = 4;
+        const int readers = 4;
+        const int iterations = 200;
+
+        var start = DateTimeOffset.UtcNow;
+
+        var tasks = new List<Task>();
+
+        for (var w = 0; w < writers; w++)
+        {
+            var monitorName = $"monitor-{w}";
+            tasks.Add(Task.Run(async () =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    // Distinct timestamps so every iteration is a real insert, not an upsert.
+                    var storedEvent = new StoredEvent(start.AddMilliseconds(i), MonitorState.Up, TimeSpan.FromMilliseconds(i), null);
+                    await Storage.SaveEventAsync(monitorName, storedEvent, cancellationToken);
+                }
+            }, cancellationToken));
+        }
+
+        for (var r = 0; r < readers; r++)
+        {
+            var monitorName = $"monitor-{r % writers}";
+            tasks.Add(Task.Run(async () =>
+            {
+                for (var i = 0; i < iterations; i++)
+                {
+                    await Storage.GetStatsAsync(monitorName, cancellationToken: cancellationToken);
+                    await Storage.GetLastEventsAsync(monitorName, cancellationToken: cancellationToken);
+                }
+            }, cancellationToken));
+        }
+
+        tasks.Add(Task.Run(async () =>
+        {
+            for (var i = 0; i < iterations; i++)
+            {
+                // A retention of one tick purges everything written so far, so the delete
+                // genuinely contends with the inserts instead of being a no-op.
+                await Storage.PurgeOldEventsAsync(TimeSpan.FromTicks(1), cancellationToken);
+            }
+        }, cancellationToken));
+
+        // Task.WhenAll surfaces the first SqliteException from any participant.
+        await Task.WhenAll(tasks);
+
+        // The database is still consistent and usable afterwards.
+        var storedEvent = new StoredEvent(DateTimeOffset.UtcNow, MonitorState.Down, null, "after");
+        await Storage.SaveEventAsync("monitor-0", storedEvent, cancellationToken);
+        var stats = await Storage.GetStatsAsync("monitor-0", cancellationToken: cancellationToken);
+        Assert.NotNull(stats);
+        Assert.Equal(MonitorState.Down, stats.LastState);
+    }
+}


### PR DESCRIPTION
Closes #20
Closes #21

## #20 — HttpMonitor

**Root cause 1.** The two static `HttpClient`s used default handlers, whose `PooledConnectionLifetime` is infinite. Connections were never recycled, so DNS changes were never picked up; a daemon running for months could keep reporting `Up` against a decommissioned IP.

**Fix.** Both clients are now built over a `SocketsHttpHandler { PooledConnectionLifetime = 2 min }`; the ignore-certificate variant sets `SslOptions.RemoteCertificateValidationCallback`. The handlers are exposed to tests via an `internal static CachedHandlers` accessor (`Deucalion.Network.csproj` gains `InternalsVisibleTo Deucalion.Tests`, mirroring `Deucalion.Api`).

**Root cause 2.** With `ExpectedResponseBodyPattern` set, `SendAsync` used `HttpCompletionOption.ResponseContentRead`, which buffers the entire response (up to the 2 GB default `MaxResponseContentBufferSize`) before the 1 MB `MaxResponseBodySize` cap was ever applied.

**Fix.** Always `ResponseHeadersRead`; the body was already streamed via `ReadAsStreamAsync` + `ReadBlockAsync`, so the cap is now real.

## #21 — SQLite connection string

**Root cause.** `Cache=Shared` is SQLite shared-cache mode, not ADO.NET pooling as the comment claimed (Microsoft.Data.Sqlite pools by default). With WAL enabled in `InitializeAsync`, shared cache replaces file-level locking with in-process table locks and can raise `SQLITE_LOCKED`, which `busy_timeout` does not retry.

**Fix.** Removed `Cache=Shared`; the comment now explains why it must not come back.

## Tests

| Test | Before | After |
|---|---|---|
| `Issue20_BodyPattern_DoesNotBufferTheWholeResponseBeforeMatching` — server streams 2 MB (needle in the first KB) and never completes the response | **Fails** (`Down`/`Timeout` after 5 s, 3/3 runs) | Passes in ~0.1 s |
| `Issue20_CachedClients_RecyclePooledConnections` — both handlers have a finite lifetime | n/a (accessor did not exist) | Passes |
| `IgnoreCertificateErrors_HandlerAcceptsAnyCertificate` — the SslOptions callback still accepts any cert | n/a | Passes |
| `BodyPattern_BeyondTheOneMegabyteCap_IsNotSeen` — 3 MB body, needle after the cap → not matched | Passes | Passes (documents the cap) |
| `Issue21_ConcurrentWritesReadsAndPurges_DoNotThrow` — 4 writers × 200 inserts, 4 readers × 200 stats+events, 200 purges, all concurrent | Passes | Passes (~1.9 s) |

Honest note on #21: the concurrency test does **not** fail on the old connection string in this harness. Microsoft.Data.Sqlite retries `SQLITE_LOCKED`/`SQLITE_BUSY` inside its prepare/step loop up to `CommandTimeout`, so shared-cache contention showed up as latency rather than an exception here. The test guards the load pattern the issue describes and will catch a regression that does throw.

Full suite locally (`dotnet test -c Release`, 3 consecutive runs): 140 total, 0 failed, 8 skipped (network-gated).
