### PR TITLE
test(service): cover Deucalion.Service middleware; fix Accept-Encoding parsing and method check on /

### DIFF
--- a/src/cs/Deucalion.Service/Program.cs
+++ b/src/cs/Deucalion.Service/Program.cs
@@ -40,3 +40,5 @@ catch (ConfigurationErrorException ex)
 }
 
 return 0;
+
+public partial class Program;

--- a/src/cs/Deucalion.Service/WebApplicationExtensions.cs
+++ b/src/cs/Deucalion.Service/WebApplicationExtensions.cs
@@ -23,13 +23,16 @@ internal static class WebApplicationExtensions
             var path = context.Request.Path.Value;
             if (path?.StartsWith("/assets/") == true)
             {
-                var acceptEncoding = context.Request.Headers.AcceptEncoding.ToString();
                 var physicalPath = Path.Combine(webRootPath, path.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+
+                // Parse Accept-Encoding as a proper token list with q-values. A substring test
+                // would match e.g. "xbr" and would serve brotli to a client sending "br;q=0".
+                StringWithQualityHeaderValue.TryParseList(context.Request.Headers.AcceptEncoding, out var acceptedEncodings);
 
                 string? compressedPath = null;
                 string? encoding = null;
 
-                if (acceptEncoding.Contains("br"))
+                if (Accepts(acceptedEncodings, "br"))
                 {
                     var brPath = physicalPath + ".br";
                     if (File.Exists(brPath))
@@ -39,7 +42,7 @@ internal static class WebApplicationExtensions
                     }
                 }
 
-                if (compressedPath is null && acceptEncoding.Contains("gzip"))
+                if (compressedPath is null && Accepts(acceptedEncodings, "gzip"))
                 {
                     var gzPath = physicalPath + ".gz";
                     if (File.Exists(gzPath))
@@ -105,6 +108,15 @@ internal static class WebApplicationExtensions
             {
                 if (context.Request.Path == "/")
                 {
+                    // The page is a read-only resource: anything but GET/HEAD is not allowed.
+                    var method = context.Request.Method;
+                    if (!HttpMethods.IsGet(method) && !HttpMethods.IsHead(method))
+                    {
+                        context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                        context.Response.Headers.Allow = "GET, HEAD";
+                        return;
+                    }
+
                     // Conditional GET: return 304 if client has current version
                     var ifNoneMatch = context.Request.Headers.IfNoneMatch.ToString();
                     if (ifNoneMatch == "*" || ifNoneMatch.Contains(etag))
@@ -118,7 +130,13 @@ internal static class WebApplicationExtensions
                     context.Response.ContentType = "text/html";
                     context.Response.Headers.CacheControl = "no-cache";
                     context.Response.Headers.ETag = etag;
-                    await context.Response.WriteAsync(cachedContent);
+
+                    // HEAD: same headers as GET, no body.
+                    if (HttpMethods.IsGet(method))
+                    {
+                        await context.Response.WriteAsync(cachedContent);
+                    }
+
                     return;
                 }
 
@@ -127,6 +145,35 @@ internal static class WebApplicationExtensions
         }
 
         return app;
+    }
+
+    /// <summary>
+    /// Whether the parsed Accept-Encoding list allows <paramref name="encoding"/>: an explicit
+    /// entry wins (its q-value decides, missing q means 1); otherwise a wildcard entry decides;
+    /// otherwise the encoding is not accepted. Comparison is case-insensitive per RFC 9110.
+    /// </summary>
+    private static bool Accepts(IList<StringWithQualityHeaderValue>? acceptedEncodings, string encoding)
+    {
+        if (acceptedEncodings is null)
+        {
+            return false;
+        }
+
+        StringWithQualityHeaderValue? wildcard = null;
+        foreach (var item in acceptedEncodings)
+        {
+            if (item.Value.Equals(encoding, StringComparison.OrdinalIgnoreCase))
+            {
+                return (item.Quality ?? 1) > 0;
+            }
+
+            if (item.Value.Equals("*", StringComparison.Ordinal))
+            {
+                wildcard = item;
+            }
+        }
+
+        return wildcard is not null && (wildcard.Quality ?? 1) > 0;
     }
 
     private static void SetImmutableCacheHeaders(HttpResponse response)

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -11,6 +11,7 @@ using Xunit;
 
 namespace Deucalion.Tests.Api;
 
+[Collection(ProcessEnvironmentCollection.Name)]
 public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
 {
     // Configuration file path is read during WebApplicationBuilder construction,

--- a/src/cs/Deucalion.Tests/Deucalion.Tests.csproj
+++ b/src/cs/Deucalion.Tests/Deucalion.Tests.csproj
@@ -22,6 +22,10 @@
     <ProjectReference Include="..\Deucalion.Core\Deucalion.Core.csproj" />
     <ProjectReference Include="..\Deucalion.Network\Deucalion.Network.csproj" />
     <ProjectReference Include="..\Deucalion.Storage\Deucalion.Storage.csproj" />
+    <!-- Aliased: Deucalion.Service and Deucalion.Api both declare a global-namespace `Program`. -->
+    <ProjectReference Include="..\Deucalion.Service\Deucalion.Service.csproj">
+      <Aliases>Service</Aliases>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/cs/Deucalion.Tests/ProcessEnvironmentCollection.cs
+++ b/src/cs/Deucalion.Tests/ProcessEnvironmentCollection.cs
@@ -1,0 +1,16 @@
+using Xunit;
+
+namespace Deucalion.Tests;
+
+/// <summary>
+/// Test classes that boot a host through <c>WebApplicationFactory</c> configure it via
+/// process-global environment variables (<c>Deucalion__ConfigurationFile</c>,
+/// <c>Deucalion__StoragePath</c>, ...) because the configuration is read during
+/// <c>WebApplication.CreateBuilder</c>, before the factory's callbacks land. xunit runs
+/// test classes in parallel, so every such class joins this collection to serialize them.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class ProcessEnvironmentCollection
+{
+    public const string Name = "ProcessEnvironment";
+}

--- a/src/cs/Deucalion.Tests/Service/ServiceHostTests.cs
+++ b/src/cs/Deucalion.Tests/Service/ServiceHostTests.cs
@@ -16,7 +16,7 @@ namespace Deucalion.Tests.Service;
 /// a throw-away <c>wwwroot</c>, and exercises that middleware over HTTP.
 /// </summary>
 [Collection(ProcessEnvironmentCollection.Name)]
-public sealed class ServiceHostTests : IAsyncLifetime, IDisposable
+public sealed class ServiceHostTests : IAsyncLifetime
 {
     // See ApiIntegrationTests for why these are environment variables.
     private const string ConfigurationFileEnvVar = "Deucalion__ConfigurationFile";
@@ -73,16 +73,19 @@ public sealed class ServiceHostTests : IAsyncLifetime, IDisposable
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
-
-    public void Dispose()
+    // Cleanup lives here, not in IDisposable.Dispose(): xunit.v3 calls only DisposeAsync() on a
+    // class that implements IAsyncLifetime, so a Dispose() would silently never run.
+    public async ValueTask DisposeAsync()
     {
+        await _factory.DisposeAsync();
+
         // ApiIntegrationTests asserts the title from appsettings.Development.json; an env var
         // would override it, so it must not outlive this class.
         Environment.SetEnvironmentVariable(PageTitleEnvVar, null);
+        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, null);
+        Environment.SetEnvironmentVariable(StoragePathEnvVar, null);
 
         TestPaths.DeleteWithRetry(_tempPath);
-        GC.SuppressFinalize(this);
     }
 
     // --- Index page ---------------------------------------------------------------------------

--- a/src/cs/Deucalion.Tests/Service/ServiceHostTests.cs
+++ b/src/cs/Deucalion.Tests/Service/ServiceHostTests.cs
@@ -1,0 +1,393 @@
+extern alias Service;
+
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Deucalion.Tests.Service;
+
+/// <summary>
+/// Boots <c>Deucalion.Service</c>'s <c>Program</c> (the Windows-service host that layers the
+/// index-page and pre-compressed static-file middleware on top of <c>Deucalion.Api</c>) against
+/// a throw-away <c>wwwroot</c>, and exercises that middleware over HTTP.
+/// </summary>
+[Collection(ProcessEnvironmentCollection.Name)]
+public sealed class ServiceHostTests : IAsyncLifetime, IDisposable
+{
+    // See ApiIntegrationTests for why these are environment variables.
+    private const string ConfigurationFileEnvVar = "Deucalion__ConfigurationFile";
+    private const string StoragePathEnvVar = "Deucalion__StoragePath";
+    private const string PageTitleEnvVar = "Deucalion__PageTitle";
+
+    private const string PageTitle = "Tom & Jerry <\"Live\">";
+    private const string ExpectedTitleElement = "<title>Tom &amp; Jerry &lt;&quot;Live&quot;&gt;</title>";
+
+    private const string IndexTemplate =
+        """
+        <!doctype html>
+        <html><head><meta charset="utf-8"><!-- $DEUCALION__PAGETITLE --></head>
+        <body><div id="root"></div></body></html>
+        """;
+
+    // Long enough to be worth compressing and to make each sidecar a distinct size.
+    private static readonly string AssetContent = string.Concat(Enumerable.Repeat("export const answer = 42;\n", 40));
+    private static readonly byte[] AssetBytes = Encoding.UTF8.GetBytes(AssetContent);
+
+    private readonly string _tempPath;
+    private readonly string _webRootPath;
+    private readonly ServiceFactory _factory;
+
+    public ServiceHostTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"Deucalion.Tests.Service_{Guid.NewGuid()}");
+        _webRootPath = Path.Combine(_tempPath, "wwwroot");
+        var assetsPath = Path.Combine(_webRootPath, "assets");
+        Directory.CreateDirectory(assetsPath);
+
+        File.WriteAllText(Path.Combine(_webRootPath, "index.html"), IndexTemplate);
+
+        // x.js has both sidecars; y.js has none.
+        File.WriteAllBytes(Path.Combine(assetsPath, "x.js"), AssetBytes);
+        File.WriteAllBytes(Path.Combine(assetsPath, "x.js.br"), Compress(AssetBytes, s => new BrotliStream(s, CompressionLevel.Optimal)));
+        File.WriteAllBytes(Path.Combine(assetsPath, "x.js.gz"), Compress(AssetBytes, s => new GZipStream(s, CompressionLevel.Optimal)));
+        File.WriteAllBytes(Path.Combine(assetsPath, "y.js"), AssetBytes);
+
+        var configurationPath = Path.Combine(_tempPath, "deucalion.yaml");
+        File.WriteAllText(configurationPath,
+            """
+            monitors:
+              checkin-only: !checkin
+                group: Main
+            """);
+
+        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, configurationPath);
+        Environment.SetEnvironmentVariable(StoragePathEnvVar, Path.Combine(_tempPath, "storage"));
+        Environment.SetEnvironmentVariable(PageTitleEnvVar, PageTitle);
+
+        _factory = new ServiceFactory(_tempPath);
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
+
+    public void Dispose()
+    {
+        // ApiIntegrationTests asserts the title from appsettings.Development.json; an env var
+        // would override it, so it must not outlive this class.
+        Environment.SetEnvironmentVariable(PageTitleEnvVar, null);
+
+        TestPaths.DeleteWithRetry(_tempPath);
+        GC.SuppressFinalize(this);
+    }
+
+    // --- Index page ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetIndex_ReturnsProcessedHtml_WithNoCacheAndETag()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+        Assert.True(response.Headers.CacheControl?.NoCache, "Cache-Control must be no-cache so the browser revalidates");
+        Assert.NotNull(response.Headers.ETag);
+        Assert.False(response.Headers.ETag.IsWeak);
+
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains(ExpectedTitleElement, html, StringComparison.Ordinal);
+        Assert.DoesNotContain("$DEUCALION__PAGETITLE", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(PageTitle, html, StringComparison.Ordinal); // never raw, always encoded
+    }
+
+    [Fact]
+    public async Task GetIndex_ETagIsStableAcrossRequests()
+    {
+        using var client = _factory.CreateClient();
+
+        using var first = await client.GetAsync("/", TestContext.Current.CancellationToken);
+        using var second = await client.GetAsync("/", TestContext.Current.CancellationToken);
+
+        Assert.Equal(first.Headers.ETag, second.Headers.ETag);
+    }
+
+    [Fact]
+    public async Task GetIndex_IfNoneMatchCurrentETag_Returns304WithoutBody()
+    {
+        using var client = _factory.CreateClient();
+
+        using var initial = await client.GetAsync("/", TestContext.Current.CancellationToken);
+        var etag = initial.Headers.ETag!;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.IfNoneMatch.Add(etag);
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        Assert.Equal(etag, response.Headers.ETag);
+        Assert.True(response.Headers.CacheControl?.NoCache);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetIndex_IfNoneMatchWildcard_Returns304()
+    {
+        using var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.IfNoneMatch.Add(EntityTagHeaderValue.Any);
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task GetIndex_IfNoneMatchStaleETag_Returns200WithBody()
+    {
+        using var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue("\"0000000000000000\""));
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.Contains(ExpectedTitleElement, html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task HeadIndex_ReturnsSameHeadersAsGet_WithoutBody()
+    {
+        using var client = _factory.CreateClient();
+
+        using var get = await client.GetAsync("/", TestContext.Current.CancellationToken);
+        using var head = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, "/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, head.StatusCode);
+        Assert.Equal("text/html", head.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(get.Headers.ETag, head.Headers.ETag);
+        Assert.True(head.Headers.CacheControl?.NoCache);
+        Assert.Empty(await head.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Theory]
+    [InlineData("POST")]
+    [InlineData("PUT")]
+    [InlineData("DELETE")]
+    [InlineData("PATCH")]
+    public async Task NonReadMethodOnIndex_Returns405WithAllow(string method)
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.SendAsync(new HttpRequestMessage(new HttpMethod(method), "/"), TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+        Assert.Equal(["GET", "HEAD"], response.Content.Headers.Allow.Order().ToArray());
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    // --- /assets: pre-compressed sidecars -----------------------------------------------------
+
+    [Fact]
+    public async Task Asset_AcceptBrotli_ServesBrotliSidecar()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", "br");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(["br"], response.Content.Headers.ContentEncoding);
+        Assert.Contains("Accept-Encoding", response.Headers.Vary);
+        Assert.Equal("text/javascript", response.Content.Headers.ContentType?.MediaType);
+        Assert.Equal(SidecarLength("x.js.br"), response.Content.Headers.ContentLength);
+        AssertImmutable(response);
+
+        var body = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(SidecarLength("x.js.br"), body.Length);
+        Assert.Equal(AssetContent, Decompress(body, s => new BrotliStream(s, CompressionMode.Decompress)));
+    }
+
+    [Fact]
+    public async Task Asset_AcceptGzip_ServesGzipSidecar()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", "gzip");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(["gzip"], response.Content.Headers.ContentEncoding);
+        Assert.Contains("Accept-Encoding", response.Headers.Vary);
+        Assert.Equal(SidecarLength("x.js.gz"), response.Content.Headers.ContentLength);
+        AssertImmutable(response);
+
+        var body = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(AssetContent, Decompress(body, s => new GZipStream(s, CompressionMode.Decompress)));
+    }
+
+    [Fact]
+    public async Task Asset_AcceptBoth_PrefersBrotli()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", "gzip, deflate, br");
+
+        Assert.Equal(["br"], response.Content.Headers.ContentEncoding);
+        Assert.Equal(SidecarLength("x.js.br"), response.Content.Headers.ContentLength);
+    }
+
+    [Fact]
+    public async Task Asset_BrotliRefusedByQValue_FallsBackToGzip()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", "br;q=0, gzip");
+
+        Assert.Equal(["gzip"], response.Content.Headers.ContentEncoding);
+        Assert.Equal(SidecarLength("x.js.gz"), response.Content.Headers.ContentLength);
+    }
+
+    [Theory]
+    [InlineData("br;q=0")]
+    [InlineData("br;q=0, gzip;q=0")]
+    [InlineData("brotli-unsupported")]
+    [InlineData("xbr")]
+    [InlineData("identity")]
+    public async Task Asset_EncodingNotAcceptable_ServesIdentity(string acceptEncoding)
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", acceptEncoding);
+
+        await AssertIdentityAsync(response);
+    }
+
+    [Fact]
+    public async Task Asset_NoAcceptEncoding_ServesIdentity()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", acceptEncoding: null);
+
+        await AssertIdentityAsync(response);
+    }
+
+    [Fact]
+    public async Task Asset_CaseInsensitiveEncodingToken_ServesSidecar()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/x.js", "BR");
+
+        Assert.Equal(["br"], response.Content.Headers.ContentEncoding);
+    }
+
+    [Fact]
+    public async Task Asset_SidecarMissing_FallsBackToOriginalFile()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/y.js", "br, gzip");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/javascript", response.Content.Headers.ContentType?.MediaType);
+        AssertImmutable(response);
+
+        // No sidecar means the static-file middleware serves y.js itself. The response
+        // compression middleware may then compress it on the fly; either way the client
+        // must end up with the original content.
+        var body = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        var content = response.Content.Headers.ContentEncoding.SingleOrDefault() switch
+        {
+            null => Encoding.UTF8.GetString(body),
+            "br" => Decompress(body, s => new BrotliStream(s, CompressionMode.Decompress)),
+            "gzip" => Decompress(body, s => new GZipStream(s, CompressionMode.Decompress)),
+            var other => throw new Xunit.Sdk.XunitException($"Unexpected Content-Encoding '{other}'"),
+        };
+        Assert.Equal(AssetContent, content);
+    }
+
+    [Fact]
+    public async Task Asset_Unknown_Returns404()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await GetAssetAsync(client, "/assets/missing.js", "br, gzip");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    private static Task<HttpResponseMessage> GetAssetAsync(HttpClient client, string path, string? acceptEncoding)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, path);
+        if (acceptEncoding is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Accept-Encoding", acceptEncoding);
+        }
+
+        return client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private async Task AssertIdentityAsync(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Empty(response.Content.Headers.ContentEncoding);
+        Assert.Equal(AssetBytes.Length, response.Content.Headers.ContentLength);
+        AssertImmutable(response);
+
+        var body = await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(AssetBytes, body);
+    }
+
+    private static void AssertImmutable(HttpResponseMessage response)
+    {
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.Public, "Cache-Control must be public");
+        Assert.Equal(TimeSpan.FromDays(365), cacheControl.MaxAge);
+        Assert.Contains(cacheControl.Extensions, x => x.Name == "immutable");
+    }
+
+    private long SidecarLength(string fileName) =>
+        new FileInfo(Path.Combine(_webRootPath, "assets", fileName)).Length;
+
+    private static byte[] Compress(byte[] input, Func<Stream, Stream> createCompressor)
+    {
+        using var output = new MemoryStream();
+        using (var compressor = createCompressor(output))
+        {
+            compressor.Write(input);
+        }
+
+        return output.ToArray();
+    }
+
+    private static string Decompress(byte[] input, Func<Stream, Stream> createDecompressor)
+    {
+        using var decompressor = createDecompressor(new MemoryStream(input));
+        using var reader = new StreamReader(decompressor, Encoding.UTF8);
+        return reader.ReadToEnd();
+    }
+
+    private sealed class ServiceFactory(string contentRoot) : WebApplicationFactory<Service::Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            // Production: the Service's Program points the web root at ../../../publish/wwwroot
+            // in Development. Outside Development it is ./wwwroot under the content root.
+            builder.UseEnvironment("Production");
+            builder.UseContentRoot(contentRoot);
+        }
+    }
+}


### PR DESCRIPTION
Closes #26

## Summary

`Deucalion.Service`'s hand-rolled middleware (`WebApplicationExtensions.cs`) had no .NET test coverage and two live bugs. This PR fixes both and adds a `WebApplicationFactory<Service::Program>` suite that boots the real Service host against a throw-away `wwwroot`.

### Fixes (`src/cs/Deucalion.Service/WebApplicationExtensions.cs`)

- **`Accept-Encoding` negotiation**: replaced the substring `Contains("br")` / `Contains("gzip")` with `StringWithQualityHeaderValue.TryParseList` plus an `Accepts()` helper. An explicit token decides by its q-value (missing q = 1, `q=0` refuses), a `*` wildcard is honoured, tokens are compared case-insensitively. `xbr` / `brotli-unsupported` no longer select the brotli sidecar; `br;q=0, gzip` falls back to gzip.
- **`/` method handling**: `POST`/`PUT`/`DELETE`/`PATCH` on `/` now return **405** with `Allow: GET, HEAD` and no body. `HEAD /` returns the GET headers (ETag, `Cache-Control: no-cache`, `Content-Type`) without writing a body (previously the body was written for every method).

### Test wiring

- `Deucalion.Service/Program.cs`: `public partial class Program;` (same as `Deucalion.Api`) so `WebApplicationFactory` can reference it.
- `Deucalion.Tests.csproj`: `ProjectReference` to `Deucalion.Service` with `<Aliases>Service</Aliases>` — both Api and Service declare a global-namespace `Program`, which is otherwise CS0433.
- New `ProcessEnvironmentCollection`: both `WebApplicationFactory` suites configure the host via process-global env vars (`Deucalion__ConfigurationFile`, `Deucalion__StoragePath`, `Deucalion__PageTitle`), so `ApiIntegrationTests` and the new `ServiceHostTests` share one xunit collection and never run concurrently. `ApiIntegrationTests` only gained the `[Collection]` attribute.
- New `src/cs/Deucalion.Tests/Service/ServiceHostTests.cs` (23 test cases). The factory runs in `Production` with `UseContentRoot(tempDir)` so the Service's `./wwwroot` resolution points at the fixture: `index.html` with the `<!-- $DEUCALION__PAGETITLE -->` placeholder, `assets/x.js` + real brotli/gzip sidecars, `assets/y.js` without sidecars.

## Coverage

| Area | Tests |
|---|---|
| `GET /` | `text/html`, `Cache-Control: no-cache`, strong ETag, title injected and HTML-encoded (`Tom & Jerry <"Live">` → `&amp; &lt;&quot;…`), placeholder gone, ETag stable across requests |
| Conditional | `If-None-Match: <etag>` → 304 (no body, ETag + no-cache kept); `If-None-Match: *` → 304; stale ETag → 200 with body |
| Methods on `/` | `HEAD` → 200 same headers no body; `POST`/`PUT`/`DELETE`/`PATCH` → 405 + `Allow: GET, HEAD` |
| `/assets/x.js` | `br` → `.br` sidecar (`Content-Encoding: br`, `Vary: Accept-Encoding`, `Content-Length` == sidecar size, body decompresses to the original); `gzip` → `.gz`; `gzip, deflate, br` → br; `br;q=0, gzip` → gzip; `BR` (case) → br |
| Identity | `br;q=0`, `br;q=0, gzip;q=0`, `brotli-unsupported`, `xbr`, `identity`, no header → uncompressed bytes, no `Content-Encoding` |
| Cache | `Cache-Control: public, max-age=31536000, immutable` asserted on every `/assets/**` response (sidecar and identity paths) |
| Fallback | `y.js` (no sidecars) with `br, gzip` → original content served (via static files + on-the-fly compression); unknown asset → 404 |

## Evidence

Local, `dotnet build -c Release` + `dotnet test -c Release` (Windows, .NET 10):

```
Test run summary: Passed!
  total: 158   failed: 0   succeeded: 150   skipped: 8   (skipped = network-gated monitor tests)
```

Same suite run with the fix commit stashed (i.e. against the middleware as on `master`), `--filter-class Deucalion.Tests.Service.ServiceHostTests`:

```
  total: 23   failed: 10   succeeded: 13
failed NonReadMethodOnIndex_Returns405WithAllow(method: "POST" | "PUT" | "DELETE" | "PATCH")
failed Asset_EncodingNotAcceptable_ServesIdentity(acceptEncoding: "br;q=0" | "br;q=0, gzip;q=0" | "xbr" | "brotli-unsupported")
failed Asset_BrotliRefusedByQValue_FallsBackToGzip
failed HeadIndex_ReturnsSameHeadersAsGet_WithoutBody
```

Not touched: `BuildIndexContent` (owned by a follow-up), the e2e suite.

## Finding outside this PR's ownership: `IDisposable.Dispose()` is dead code under xunit.v3

The first CI run failed: `ApiIntegrationTests.GetConfiguration_ReturnsConfiguredMetadata` saw my `Deucalion__PageTitle` env var. Cause: xunit.v3 calls **only** `DisposeAsync()` on a class implementing `IAsyncLifetime`; an additional `IDisposable.Dispose()` is silently never invoked. Evidence: after a few local runs there were 92 `Deucalion.Tests.Service_*` and **224 `Deucalion.Tests.Api_*`** directories left in `%TEMP%` — the latter from `ApiIntegrationTests.Dispose()`, which also never resets `Deucalion__ConfigurationFile`/`Deucalion__StoragePath` and never deletes its temp dir. After moving my cleanup into `DisposeAsync` (commit 3), zero Service directories leak.

`ApiIntegrationTests.cs` is owned by another change in this wave, so I only added the `[Collection]` attribute there; its `Dispose()` body should move into `DisposeAsync()` the same way (`SqliteStorageTestBase` has the same pattern and is worth checking too).
