### PR TITLE
fix(ui): frontend perf/a11y cleanups and font tokens instead of #dynamic-fonts (#27, #33)

### DIFF
--- a/src/ts/deucalion-ui/src/components/hero/hero-availability.tsx
+++ b/src/ts/deucalion-ui/src/components/hero/hero-availability.tsx
@@ -27,11 +27,12 @@ export const HeroAvailability: Component = () => {
     return buckets.reverse();
   });
 
-  const fmtPct = (n: number): { whole: string; dec: string } => {
-    const fixed = n.toFixed(2);
-    const [whole, dec] = fixed.split(".");
-    return { whole: whole, dec };
-  };
+  // Split "99.57" into its parts once per availability change so the
+  // decimals can be styled separately.
+  const pct = createMemo((): { whole: string; dec: string } => {
+    const [whole, dec] = agg().weightedAvailability.toFixed(2).split(".");
+    return { whole, dec };
+  });
 
   return (
     <div class="hero-stat">
@@ -40,8 +41,8 @@ export const HeroAvailability: Component = () => {
         <div class="hero-meta hero-meta-right">trend <em>response</em></div>
         <div class="hero-content-left">
           <div class="hero-availability">
-            <span>{fmtPct(agg().weightedAvailability).whole}</span>
-            <span class="pct">.{fmtPct(agg().weightedAvailability).dec}%</span>
+            <span>{pct().whole}</span>
+            <span class="pct">.{pct().dec}%</span>
           </div>
           <div class="hero-summary-row">
             <span class="hero-chip up"><strong>{agg().states.up.toString()}</strong> online</span>

--- a/src/ts/deucalion-ui/src/components/monitor/heartbeat-strip.test.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/heartbeat-strip.test.tsx
@@ -1,19 +1,31 @@
 import { render } from "@solidjs/testing-library";
-import { beforeAll, describe, expect, it } from "vitest";
+import { createSignal } from "solid-js";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { buildEvent, buildEvents } from "../../test/fixtures";
 import { MonitorState } from "../../services/deucalion-types";
+import { fmtTime } from "../../services/formatting";
 
 import { HeartbeatStrip } from "./heartbeat-strip";
 
-// Strip length is viewport-tier'd: <720 → 60, 720–1279 → 90, ≥1280 → 120.
+// Strip length is viewport-tier'd: <1280 → 60, 1280–1479 → 90, ≥1480 → 120.
 // Pin a narrow viewport for these tests so we exercise the 60-tick tier
 // (the assertions about padding + colour ordering are tier-agnostic).
 const STRIP_LEN = 60;
 
+const setViewport = (width: number): void => {
+  Object.defineProperty(window, "innerWidth", { configurable: true, value: width });
+};
+
 describe("<HeartbeatStrip>", () => {
   beforeAll(() => {
-    Object.defineProperty(window, "innerWidth", { configurable: true, value: 500 });
+    setViewport(500);
+  });
+
+  afterEach(() => {
+    setViewport(500);
+    window.dispatchEvent(new Event("resize"));
+    vi.useRealTimers();
   });
 
   it("always renders 60 ticks at narrow viewports", () => {
@@ -45,5 +57,94 @@ describe("<HeartbeatStrip>", () => {
     expect(ticks[STRIP_LEN - 3]).toHaveClass("up");
     expect(ticks[STRIP_LEN - 2]).toHaveClass("warn");
     expect(ticks[STRIP_LEN - 1]).toHaveClass("down");
+  });
+
+  it("keeps the data-tip wire format on the newest tick (read by the e2e wire-contract test)", () => {
+    const events = [buildEvent({ at: 1_700_000_000, st: MonitorState.Up, ms: 42 })];
+    const { container } = render(() => <HeartbeatStrip events={events} />);
+    const newest = container.querySelector(".tick:last-child");
+    expect(newest).toHaveAttribute("data-tip", `Up · ${fmtTime(1_700_000_000)} · 42ms`);
+  });
+
+  it("shares one resize listener across every strip (issue #27)", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    for (let i = 0; i < 10; i++) render(() => <HeartbeatStrip events={[]} />);
+    const resizeRegistrations = addSpy.mock.calls.filter(([type]) => type === "resize");
+    addSpy.mockRestore();
+    // The listener is attached lazily on first use, so an earlier test in this
+    // file may already have registered it: at most one, never one per strip.
+    expect(resizeRegistrations.length).toBeLessThanOrEqual(1);
+  });
+
+  it("re-tiers every mounted strip on a single resize event", () => {
+    const a = render(() => <HeartbeatStrip events={[]} />);
+    const b = render(() => <HeartbeatStrip events={[]} />);
+    expect(a.container.querySelectorAll(".tick")).toHaveLength(60);
+    expect(b.container.querySelectorAll(".tick")).toHaveLength(60);
+
+    setViewport(1500);
+    window.dispatchEvent(new Event("resize"));
+    expect(a.container.querySelectorAll(".tick")).toHaveLength(120);
+    expect(b.container.querySelectorAll(".tick")).toHaveLength(120);
+
+    setViewport(1300);
+    window.dispatchEvent(new Event("resize"));
+    expect(a.container.querySelectorAll(".tick")).toHaveLength(90);
+    expect(b.container.querySelectorAll(".tick")).toHaveLength(90);
+  });
+
+  it("flags the strip container (not each tick) as fresh for ~600ms when a new event lands", () => {
+    vi.useFakeTimers();
+    const initial = buildEvents([MonitorState.Up]);
+    const [events, setEvents] = createSignal(initial);
+    const { container } = render(() => <HeartbeatStrip events={events()} />);
+    const strip = container.querySelector(".col-strip")!;
+
+    // Initial render counts as a fresh event too.
+    expect(strip).toHaveClass("is-fresh");
+    vi.advanceTimersByTime(600);
+    expect(strip).not.toHaveClass("is-fresh");
+
+    setEvents([buildEvent({ at: 1_700_000_100, st: MonitorState.Down, ms: undefined }), ...initial]);
+    expect(strip).toHaveClass("is-fresh");
+    // No per-tick class: the CSS targets `.col-strip.is-fresh .tick:last-child`.
+    expect(container.querySelectorAll(".tick.fresh")).toHaveLength(0);
+    expect(container.querySelector(".tick:last-child")).toHaveClass("down");
+
+    vi.advanceTimersByTime(600);
+    expect(strip).not.toHaveClass("is-fresh");
+  });
+
+  it("does not re-flag fresh when the events array changes without a newer event", () => {
+    vi.useFakeTimers();
+    const initial = buildEvents([MonitorState.Up, MonitorState.Up]);
+    const [events, setEvents] = createSignal(initial);
+    const { container } = render(() => <HeartbeatStrip events={events()} />);
+    const strip = container.querySelector(".col-strip")!;
+    vi.advanceTimersByTime(600);
+    expect(strip).not.toHaveClass("is-fresh");
+
+    setEvents([...initial]); // same newest timestamp, new array identity
+    expect(strip).not.toHaveClass("is-fresh");
+  });
+
+  it("exposes the newest check to assistive tech and keyboard users", () => {
+    const events = [
+      buildEvent({ at: 1_700_000_010, st: MonitorState.Warn, ms: 250 }),
+      buildEvent({ at: 1_700_000_000, st: MonitorState.Up, ms: 42 }),
+    ];
+    const { container } = render(() => <HeartbeatStrip events={events} />);
+    const strip = container.querySelector(".col-strip")!;
+    expect(strip).toHaveAttribute("role", "img");
+    expect(strip).toHaveAttribute("tabindex", "0");
+    expect(strip).toHaveAttribute(
+      "aria-label",
+      `Recent check history: 2 checks, latest Warn · ${fmtTime(1_700_000_010)} · 250ms`,
+    );
+  });
+
+  it("names an empty strip without pretending to have data", () => {
+    const { container } = render(() => <HeartbeatStrip events={[]} />);
+    expect(container.querySelector(".col-strip")).toHaveAttribute("aria-label", "Recent check history: no checks yet");
   });
 });

--- a/src/ts/deucalion-ui/src/components/monitor/heartbeat-strip.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/heartbeat-strip.tsx
@@ -1,4 +1,4 @@
-import { For, type Component, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
+import { For, type Accessor, type Component, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 import type { MonitorEventDto } from "../../services/deucalion-types";
 import { fmtMs, fmtTime, stateLabel, stateName } from "../../services/formatting";
@@ -17,15 +17,17 @@ const stripLenForWidth = (w: number): number => {
   return 60;
 };
 
-const useStripLen = (): (() => number) => {
-  const [len, setLen] = createSignal(
-    typeof window === "undefined" ? 60 : stripLenForWidth(window.innerWidth),
-  );
-  onMount(() => {
-    const update = (): void => { setLen(stripLenForWidth(window.innerWidth)); };
-    window.addEventListener("resize", update);
-    onCleanup(() => { window.removeEventListener("resize", update); });
-  });
+// One signal + one `resize` listener shared by every strip on the page.
+// Attached lazily on first use so importing this module has no side effects
+// (tests pin `window.innerWidth` before rendering, and SSR has no window).
+let sharedStripLen: Accessor<number> | undefined;
+
+const useStripLen = (): Accessor<number> => {
+  if (sharedStripLen) return sharedStripLen;
+  if (typeof window === "undefined") return () => 60;
+  const [len, setLen] = createSignal(stripLenForWidth(window.innerWidth));
+  window.addEventListener("resize", () => { setLen(stripLenForWidth(window.innerWidth)); });
+  sharedStripLen = len;
   return len;
 };
 
@@ -33,20 +35,25 @@ interface HeartbeatStripProps {
   events: MonitorEventDto[]; // newest-first
 }
 
+const tipFor = (ev: MonitorEventDto): string =>
+  `${stateLabel(ev.st)} · ${fmtTime(ev.at)}${ev.ms != null ? ` · ${fmtMs(ev.ms)}` : ""}`;
+
 export const HeartbeatStrip: Component<HeartbeatStripProps> = (props) => {
-  const [freshSig, setFreshSig] = createSignal(0);
+  const [fresh, setFresh] = createSignal(false);
   let lastSeenAt: number | undefined;
   const stripLen = useStripLen();
 
-  // When the freshest event timestamp changes, set the fresh signal so the
-  // rightmost tick gets the .fresh class for ~600ms.
+  // When the freshest event timestamp changes, flag the strip as fresh for
+  // ~600ms. CSS (`.col-strip.is-fresh .tick:last-child`) animates the newest
+  // tick, so this is a single binding on the container rather than one
+  // per tick.
   createEffect(() => {
     if (props.events.length === 0) return;
     const top = props.events[0].at;
     if (top === lastSeenAt) return;
     lastSeenAt = top;
-    setFreshSig(Date.now());
-    const id = setTimeout(() => { setFreshSig(0); }, 600);
+    setFresh(true);
+    const id = setTimeout(() => { setFresh(false); }, 600);
     onCleanup(() => { clearTimeout(id); });
   });
 
@@ -63,14 +70,29 @@ export const HeartbeatStrip: Component<HeartbeatStripProps> = (props) => {
     return arr;
   });
 
+  // Accessible name for the whole strip. The per-tick tooltips are CSS-only
+  // (hover), so the newest check's detail is surfaced here for screen
+  // readers, and the strip is focusable so keyboard users can reveal the
+  // same tooltip (see `.col-strip:focus-visible` in layout.css).
+  const label = createMemo((): string => {
+    const evs = props.events;
+    if (evs.length === 0) return "Recent check history: no checks yet";
+    const shown = Math.min(stripLen(), evs.length);
+    return `Recent check history: ${shown.toString()} checks, latest ${tipFor(evs[0])}`;
+  });
+
   return (
-    <div class="col-strip" role="img" aria-label="Recent check history">
+    <div
+      class="col-strip"
+      classList={{ "is-fresh": fresh() }}
+      role="img"
+      tabindex="0"
+      aria-label={label()}
+    >
       <For each={oldestToNewest()}>
-        {(ev, i) => {
-          const fresh = (): boolean => i() === stripLen() - 1 && freshSig() !== 0;
+        {(ev) => {
           if (ev === null) return <span class="tick unknown" />;
-          const tip = `${stateLabel(ev.st)} · ${fmtTime(ev.at)}${ev.ms != null ? ` · ${fmtMs(ev.ms)}` : ""}`;
-          return <span class={`tick ${stateName(ev.st)}${fresh() ? " fresh" : ""}`} data-tip={tip} />;
+          return <span class={`tick ${stateName(ev.st)}`} data-tip={tipFor(ev)} />;
         }}
       </For>
     </div>

--- a/src/ts/deucalion-ui/src/components/top-bar.title.test.tsx
+++ b/src/ts/deucalion-ui/src/components/top-bar.title.test.tsx
@@ -1,0 +1,29 @@
+import { render, waitFor } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
+
+// `configuration` is a module-level resource that fetches once on import, so
+// the page title must be stubbed before this file's imports are evaluated.
+vi.hoisted(() => {
+  vi.stubGlobal("fetch", vi.fn(async (): Promise<Response> =>
+    new Response(JSON.stringify({ pageTitle: "Araponga *status* page" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  ));
+});
+
+import { TopBar } from "./top-bar";
+
+describe("<TopBar> title emphasis", () => {
+  it("renders the *emphasis* fragment as <em> with plain head and tail", async () => {
+    const { container } = render(() => <TopBar />);
+    const brand = container.querySelector(".brand-name")!;
+
+    await waitFor(() => { expect(brand.querySelector("em")).not.toBeNull(); });
+
+    expect(brand.querySelector("em")?.textContent).toBe("status");
+    expect(brand.textContent).toBe("Araponga status page");
+    // document.title drops the markers entirely.
+    expect(document.title).toBe("Araponga status page");
+  });
+});

--- a/src/ts/deucalion-ui/src/components/top-bar.tsx
+++ b/src/ts/deucalion-ui/src/components/top-bar.tsx
@@ -1,4 +1,4 @@
-import { createEffect, Show, type Component } from "solid-js";
+import { createEffect, createMemo, Show, type Component } from "solid-js";
 
 import { configuration } from "../stores/configuration-store";
 import { monitorList } from "../stores/monitors-store";
@@ -22,6 +22,7 @@ const parseTitle = (t: string): { head: string; emphasis: string; tail: string }
 
 export const TopBar: Component = () => {
   const pageTitle = (): string => configuration()?.pageTitle ?? "Deucalion";
+  const title = createMemo(() => parseTitle(pageTitle()));
 
   const downCount = (): number => {
     let n = 0;
@@ -52,11 +53,11 @@ export const TopBar: Component = () => {
       <div class="brand">
         <img class="brand-icon" src="/assets/deucalion-icon.svg" alt="" />
         <h1 class="brand-name">
-          {parseTitle(pageTitle()).head}
-          <Show when={parseTitle(pageTitle()).emphasis}>
-            <em>{parseTitle(pageTitle()).emphasis}</em>
+          {title().head}
+          <Show when={title().emphasis}>
+            <em>{title().emphasis}</em>
           </Show>
-          {parseTitle(pageTitle()).tail}
+          {title().tail}
         </h1>
       </div>
       <div class="topbar-right">

--- a/src/ts/deucalion-ui/src/services/logger.test.ts
+++ b/src/ts/deucalion-ui/src/services/logger.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The logger reads `import.meta.env.DEV` at module load, so each case
+// re-imports a fresh copy under the stubbed environment.
+const loadLogger = async (dev: boolean): Promise<typeof import("./logger")> => {
+  vi.resetModules();
+  vi.stubEnv("DEV", dev);
+  return await import("./logger");
+};
+
+describe("logger", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("writes to the console in development", async () => {
+    const logger = await loadLogger(true);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    logger.log("a", 1);
+    logger.warn("b");
+    logger.error("c", new Error("x"));
+
+    expect(logSpy).toHaveBeenCalledWith("a", 1);
+    expect(warnSpy).toHaveBeenCalledWith("b");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ships silent in production builds (issue #27)", async () => {
+    const logger = await loadLogger(false);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    logger.log("a");
+    logger.warn("b");
+    logger.error("c");
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/ts/deucalion-ui/src/services/logger.ts
+++ b/src/ts/deucalion-ui/src/services/logger.ts
@@ -1,6 +1,9 @@
 type LogLevelType = "debug" | "error" | "info" | "log" | "trace" | "warn";
 
-let enabled = true;
+// Console output is a development aid only: production builds ship silent
+// (`import.meta.env.DEV` is statically false there, so the branch is
+// dead-code-eliminated by vite).
+const enabled: boolean = import.meta.env.DEV;
 
 const writeLog = (logLevel: LogLevelType, ...data: unknown[]) => {
   if (enabled) {
@@ -18,8 +21,4 @@ export const warn = (...data: unknown[]): void => {
 
 export const error = (...data: unknown[]): void => {
   writeLog("error", ...data);
-};
-
-export const disableLogger = (): void => {
-  enabled = false;
 };

--- a/src/ts/deucalion-ui/src/stores/tweaks-store.test.ts
+++ b/src/ts/deucalion-ui/src/stores/tweaks-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetTweaksForTests, tweaks } from "./tweaks-store";
 
@@ -30,11 +30,41 @@ describe("tweaks-store", () => {
     expect(root.style.getPropertyValue("--flash")).toContain("220");
   });
 
-  it("rewrites the dynamic-fonts <style> tag on font change", () => {
+  it("applies fonts as custom properties on the documentElement (issue #33)", () => {
+    const root = document.documentElement;
+
+    tweaks.setMonoFont("spacemono");
+    tweaks.setUiFont("system");
+    tweaks.setDisplayFont("newsreader");
+    expect(root.style.getPropertyValue("--font-mono")).toBe('"Space Mono", ui-monospace, monospace');
+    expect(root.style.getPropertyValue("--font-ui")).toContain("system-ui");
+    expect(root.style.getPropertyValue("--font-display")).toBe('"Newsreader", Georgia, serif');
+    expect(root.style.getPropertyValue("--display-italic")).toBe("italic");
+
+    // A display face that does not italicize flips the token back to normal.
+    tweaks.setDisplayFont("ibmsans");
+    expect(root.style.getPropertyValue("--font-display")).toBe('"IBM Plex Sans", sans-serif');
+    expect(root.style.getPropertyValue("--display-italic")).toBe("normal");
+  });
+
+  it("no longer injects a #dynamic-fonts stylesheet (issue #33)", () => {
     tweaks.setMonoFont("ibmmono");
-    const tag = document.getElementById("dynamic-fonts");
-    expect(tag).not.toBeNull();
-    expect(tag!.textContent).toContain("IBM Plex Mono");
+    expect(document.getElementById("dynamic-fonts")).toBeNull();
+    expect(document.querySelectorAll("style")).toHaveLength(0);
+  });
+
+  it("falls back to a known face for an unknown font key", () => {
+    tweaks.setMonoFont("does-not-exist");
+    expect(document.documentElement.style.getPropertyValue("--font-mono")).toBe('"JetBrains Mono", ui-monospace, monospace');
+  });
+
+  it("persists exactly once per change (single effect, issue #27)", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    tweaks.setAccentHue(12);
+    expect(setItem).toHaveBeenCalledTimes(1);
+    tweaks.setMonoFont("spacemono");
+    expect(setItem).toHaveBeenCalledTimes(2);
+    setItem.mockRestore();
   });
 
   it("persists every signal to localStorage", () => {

--- a/src/ts/deucalion-ui/src/stores/tweaks-store.ts
+++ b/src/ts/deucalion-ui/src/stores/tweaks-store.ts
@@ -104,36 +104,23 @@ const applyThemeAndAccent = (): void => {
 
 const applyFonts = (): void => {
   if (typeof document === "undefined") return;
+  const root = document.documentElement;
   const disp = DISPLAY_FONTS[displayFont()] ?? DISPLAY_FONTS.newsreader;
   const ui = UI_FONTS[uiFont()] ?? UI_FONTS.inter;
   const mono = MONO_FONTS[monoFont()] ?? MONO_FONTS.jetbrains;
-  const italic = disp.italicize ? "italic" : "normal";
-  let tag = document.getElementById("dynamic-fonts");
-  if (!tag) {
-    tag = document.createElement("style");
-    tag.id = "dynamic-fonts";
-    document.head.appendChild(tag);
-  }
-  tag.textContent = `
-    html, body, .ui-font { font-family: ${ui.stack} !important; }
-    .mono, .group-meta, .row-name, .type-badge, .lat-stats, .avail, .last-incident,
-    .subgroup, .footer, [data-tip]:hover::after, .hero-chip strong,
-    .hero-meta em, .tnum, .col-stats .lat-stats span strong
-      { font-family: ${mono.stack} !important; }
-    .serif, .brand-name, .hero-availability, .group-title, .footer em
-      { font-family: ${disp.stack} !important; }
-    .brand-name em, .group-title em, .footer em, .hero-availability .pct
-      { font-style: ${italic} !important; }
-    :root { --display-italic: ${italic}; }
-  `;
+  // The stylesheets only ever reference these tokens (tokens.css declares
+  // the defaults), so overriding them on the root is enough — no injected
+  // stylesheet, no selector list to keep in sync.
+  root.style.setProperty("--font-display", disp.stack);
+  root.style.setProperty("--font-ui", ui.stack);
+  root.style.setProperty("--font-mono", mono.stack);
+  root.style.setProperty("--display-italic", disp.italicize ? "italic" : "normal");
 };
 
+// A single effect: `persist()` reads every signal anyway, so splitting the
+// appliers across two effects only made each change persist twice.
 createEffect(() => {
   applyThemeAndAccent();
-  persist();
-});
-
-createEffect(() => {
   applyFonts();
   persist();
 });

--- a/src/ts/deucalion-ui/src/styles/layout.css
+++ b/src/ts/deucalion-ui/src/styles/layout.css
@@ -205,6 +205,7 @@
 .hero-meta-left  { grid-area: lavail; }
 .hero-meta-right { grid-area: ltrend; text-align: right; }
 .hero-meta em {
+  font-family: var(--font-mono);
   font-style: italic;
   color: var(--accent);
   text-transform: none;
@@ -457,8 +458,19 @@
 .tick.down { background: var(--down); }
 .tick.unknown { background: var(--unknown); opacity: 0.5; }
 
-.tick.fresh {
+/* The strip flags itself `.is-fresh` for ~600ms after a new event lands;
+   the newest tick is always the last child, so one class on the container
+   animates it without a reactive binding per tick. */
+.col-strip.is-fresh .tick:last-child {
   animation: tick-in 0.4s cubic-bezier(0.2, 0.9, 0.3, 1.4) both;
+}
+
+/* Keyboard users: focusing the strip reveals the newest tick's tooltip
+   (mouse users hover any tick — see the [data-tip] rule). */
+.col-strip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 @keyframes tick-in {
@@ -638,7 +650,8 @@
 [data-tip] {
   position: relative;
 }
-[data-tip]:hover::after {
+[data-tip]:hover::after,
+.col-strip:focus-visible .tick:last-child[data-tip]::after {
   content: attr(data-tip);
   position: absolute;
   bottom: calc(100% + 6px);


### PR DESCRIPTION
Frontend performance/accessibility cleanups (#27) and removal of the injected `#dynamic-fonts` `!important` stylesheet (#33). All changes are in `src/ts/deucalion-ui/src/`; no files outside the frontend were touched.

## #33 — fonts via custom properties

- `stores/tweaks-store.ts`: `applyFonts()` now sets `--font-display`, `--font-ui`, `--font-mono` and `--display-italic` on `documentElement`, exactly like the `--accent-*` vars. The `<style id="dynamic-fonts">` injection and its drifted selector list are gone; the bundle contains zero `!important`.
- The two effects (theme+accent / fonts) are collapsed into one — both called `persist()`, so every change was written to localStorage twice.
- `styles/layout.css`: `.hero-meta em` gets `font-family: var(--font-mono)` — it was the only element that relied solely on the `!important` list for its face (every other selector in that list already read the token).

## #27 — performance + accessibility

- `components/monitor/heartbeat-strip.tsx`
  - `useStripLen()` is now a lazily-attached module-level shared signal: one `resize` listener for the whole page instead of one per row.
  - Freshness is a single `classList` binding on the container (`.col-strip.is-fresh`); `layout.css` animates `.col-strip.is-fresh .tick:last-child` (newest tick is always the last child). One SSE event now flips one binding instead of up to 120 per-tick `class` computations.
  - Accessibility: the strip's `aria-label` names the newest check (`Recent check history: N checks, latest Up · 12:00:00 · 42ms`), the strip is focusable (`tabindex="0"`), and `:focus-visible` reveals the newest tick's CSS tooltip for keyboard users. `data-tip` and its format are unchanged (the Playwright wire-contract test reads it).
- `services/logger.ts`: `enabled = import.meta.env.DEV`; `disableLogger()` (no callers) deleted. Verified the production bundle has no `console.*` references.
- `components/top-bar.tsx`: `parseTitle(pageTitle())` ×4 → one `createMemo`.
- `components/hero/hero-availability.tsx`: `fmtPct(...)` ×2 → one `createMemo`.

## Tests

New/updated vitest coverage — 9 of the new tests fail against the pre-fix sources and pass after (verified by checking out `origin/master` sources and re-running):

- `heartbeat-strip.test.tsx`: single resize listener across 10 strips; a single resize re-tiers every mounted strip (60→120→90); `.is-fresh` on the container for 600ms with no per-tick `.fresh`; no re-flag when the array changes without a newer event; `aria-label`/`tabindex`; `data-tip` wire format pinned.
- `logger.test.ts`: logs under `DEV=true`, silent under `DEV=false` (`vi.stubEnv` + `vi.resetModules`).
- `tweaks-store.test.ts`: font tokens on `documentElement` incl. `--display-italic` normal/italic; no `#dynamic-fonts` / no `<style>` injected; unknown key falls back; `localStorage.setItem` called exactly once per change.
- `top-bar.title.test.tsx`: `*emphasis*` renders as `<em>`, `document.title` drops the markers.

Local: `npm ci`, `npm run test` (19 files / 128 tests pass), `npm run lint` (0 warnings), `npm run build` OK. e2e left to CI.

Closes #27
Closes #33
