### PR TITLE
ci: GitVersion tool manifest, reusable docker-publish workflow, PR coverage gaps

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "gitversion.tool": {
+      "version": "6.8.2",
+      "commands": [
+        "dotnet-gitversion"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,19 +3,52 @@ name: build
 on:
   pull_request:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      network-tests:
+        description: Also run the DNS/ICMP tests that need the public internet.
+        type: boolean
+        default: false
+  schedule:
+    # Weekly, Monday 06:00 UTC: the only run of the DNS/ICMP tests, which need
+    # the public internet and are skipped everywhere else.
+    - cron: '0 6 * * 1'
 
 permissions:
   contents: read
 
+# One run per branch; a newer push to a PR cancels the run it supersedes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_NOLOGO: true
+  # The xunit.v3 project runs on Microsoft.Testing.Platform (global.json). If
+  # that opt-in is lost, `dotnet test` finds nothing and exits 0; the floor
+  # makes it fail instead. ~80% of the 127 tests that run without network
+  # access. Keep in sync with $MinimumExpectedTests in Deucalion.build.ps1.
+  MINIMUM_EXPECTED_TESTS: 101
+  # Gate for the DNS/ICMP tests. '1' only on the weekly schedule and on manual
+  # runs that ask for it.
+  DEUCALION_TESTS_NETWORK: ${{ (github.event_name == 'schedule' || inputs.network-tests == true) && '1' || '0' }}
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+
+      # Node first: deucalion-ui.esproj is part of the solution and shells out
+      # to `npm install` during `dotnet build`, so the pinned Node must already
+      # be on PATH.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          cache-dependency-path: src/ts/deucalion-ui/package-lock.json
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -28,13 +61,9 @@ jobs:
         run: dotnet build --no-restore -c Release
 
       - name: Test .NET
-        run: dotnet test --no-build -c Release
-
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 'lts/*'
-          cache: npm
-          cache-dependency-path: src/ts/deucalion-ui/package-lock.json
+        # `--` hands the option to the test host; without it `dotnet test`
+        # silently ignores --minimum-expected-tests.
+        run: dotnet test --no-build -c Release -- --minimum-expected-tests "$MINIMUM_EXPECTED_TESTS"
 
       - name: Install npm dependencies
         working-directory: src/ts/deucalion-ui
@@ -84,3 +113,41 @@ jobs:
             src/ts/deucalion-ui/test-results/
             src/ts/deucalion-ui/playwright-report/
           retention-days: 7
+
+  # The product ships as a Windows Service and the build script is
+  # PowerShell; this leg keeps the .NET side honest on Windows. Frontend
+  # unit/e2e tests are platform-independent and run on Linux only.
+  test-windows:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          cache-dependency-path: src/ts/deucalion-ui/package-lock.json
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore .NET dependencies
+        run: dotnet restore
+
+      - name: Build .NET
+        run: dotnet build --no-restore -c Release
+
+      - name: Test .NET
+        run: dotnet test --no-build -c Release -- --minimum-expected-tests "$env:MINIMUM_EXPECTED_TESTS"
+
+  # Build-only Docker/AOT image (amd64) so trim and AOT publish failures
+  # surface on the PR instead of on the `edge` push after merge.
+  docker:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/docker-publish.yml
+    permissions:
+      contents: read
+    with:
+      push: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,215 @@
+name: docker-publish
+
+# Reusable: builds the container image and, optionally, pushes it to ghcr.io
+# with a multi-arch manifest. `edge` and `release` are thin callers; `build`
+# calls it with push=false so trim/AOT failures surface on PRs.
+#
+# The frontend is built exactly once, in the `frontend` job, and injected into
+# the per-arch image builds through a named build context that overrides the
+# Dockerfile's `build-node` stage ("the context overrides a stage called `name`
+# when used as `FROM ... AS name`" -- docker buildx build --build-context).
+# The Dockerfile itself is unchanged and still works standalone.
+
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: >-
+          Push the per-arch images to ghcr.io and create the multi-arch
+          manifest. When false only linux/amd64 is built and nothing leaves
+          the runner.
+        type: boolean
+        default: false
+      tags:
+        description: >-
+          Image tags to publish, one per line. `{majorMinorPatch}`, `{major}`
+          and `{minor}` are replaced with the GitVersion values. Required when
+          `push` is true.
+        type: string
+        default: ''
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/deucalion
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      semVer: ${{ steps.gitversion.outputs.semVer }}
+      majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
+      major: ${{ steps.gitversion.outputs.major }}
+      minor: ${{ steps.gitversion.outputs.minor }}
+      informationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # GitVersion needs the full history (it walks back to the last tag).
+          fetch-depth: 0
+
+      # actions/checkout leaves a detached HEAD on tag pushes (and on PR merge
+      # refs). GitVersion then has to guess which branch the commit belongs to
+      # and, with GitHubFlow, may pick a feature branch that also contains it,
+      # producing a pre-release version for a release tag. Putting the commit
+      # on a local default branch makes the answer unambiguous. On a push to
+      # master this is a no-op.
+      - name: Normalize Git state for GitVersion
+        run: git checkout -B ${{ github.event.repository.default_branch }} ${{ github.sha }}
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      # GitVersion is pinned in .config/dotnet-tools.json -- the same one
+      # `Invoke-Build Version` uses locally.
+      - name: Restore dotnet tools
+        run: dotnet tool restore
+
+      - id: gitversion
+        run: |
+          dotnet gitversion /output json > version.json
+          cat version.json
+          for key in semVer majorMinorPatch major minor informationalVersion; do
+            echo "${key}=$(jq -r ".${key^}" version.json)" >> "$GITHUB_OUTPUT"
+          done
+
+  frontend:
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          cache-dependency-path: src/ts/deucalion-ui/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: src/ts/deucalion-ui
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: src/ts/deucalion-ui
+        env:
+          VITE_BUILD_VERSION: ${{ needs.version.outputs.semVer }}
+          VITE_INFORMATIONAL_VERSION: ${{ needs.version.outputs.informationalVersion }}
+        run: npm run build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: frontend-dist
+          path: src/ts/deucalion-ui/dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  docker:
+    needs: [version, frontend]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both arches when publishing; amd64 only for the PR smoke build.
+        include: ${{ fromJSON(inputs.push && '[{"runner":"ubuntu-latest","platform":"linux/amd64"},{"runner":"ubuntu-24.04-arm","platform":"linux/arm64"}]' || '[{"runner":"ubuntu-latest","platform":"linux/amd64"}]') }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      # The Dockerfile copies `/source/dist` out of the `build-node` stage, so
+      # the replacement context must carry the same layout.
+      - uses: actions/download-artifact@v8
+        with:
+          name: frontend-dist
+          path: /tmp/frontend/source/dist
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        if: inputs.push
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (and push by digest)
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./src
+          file: ./src/Dockerfile
+          platforms: ${{ matrix.platform }}
+          build-contexts: |
+            build-node=/tmp/frontend
+          outputs: ${{ inputs.push && format('type=image,"name={0}/{1}",push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || '' }}
+          build-args: |
+            VERSION=${{ needs.version.outputs.semVer }}
+            INFORMATIONAL_VERSION=${{ needs.version.outputs.informationalVersion }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+
+      - name: Export digest
+        if: inputs.push
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@v7
+        if: inputs.push
+        with:
+          name: digest-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    if: inputs.push
+    needs: [version, docker]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Create multi-arch manifest and push
+        env:
+          TAGS: ${{ inputs.tags }}
+          MAJOR_MINOR_PATCH: ${{ needs.version.outputs.majorMinorPatch }}
+          MAJOR: ${{ needs.version.outputs.major }}
+          MINOR: ${{ needs.version.outputs.minor }}
+        run: |
+          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+
+          tag_args=()
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            tag="${tag//\{majorMinorPatch\}/$MAJOR_MINOR_PATCH}"
+            tag="${tag//\{major\}/$MAJOR}"
+            tag="${tag//\{minor\}/$MINOR}"
+            tag_args+=(--tag "${image}:${tag}")
+          done <<< "$TAGS"
+
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "::error::No tags to publish. Pass the 'tags' input."
+            exit 1
+          fi
+
+          digests=$(cd /tmp/digests && printf "${image}@sha256:%s " *)
+
+          echo "Publishing: ${tag_args[*]}"
+          docker buildx imagetools create "${tag_args[@]}" ${digests}

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -8,11 +8,11 @@ permissions:
   contents: read
   packages: write
 
-env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_NOLOGO: true
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/deucalion
+# Serialize master pushes so two runs never race to push the `:edge` manifest.
+# A newer push supersedes the one in flight.
+concurrency:
+  group: edge
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -21,94 +21,12 @@ jobs:
       contents: read
       packages: read
 
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      semVer: ${{ steps.gitversion.outputs.semVer }}
-      informationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - uses: gittools/actions/gitversion/setup@v4
-        with:
-          versionSpec: '6.x'
-
-      - id: gitversion
-        uses: gittools/actions/gitversion/execute@v4
-
   docker:
-    needs: [test, version]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./src
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
-          build-args: |
-            VERSION=${{ needs.version.outputs.semVer }}
-            INFORMATIONAL_VERSION=${{ needs.version.outputs.informationalVersion }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: digest-${{ matrix.runner }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  publish:
-    needs: [version, docker]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/download-artifact@v8
-        with:
-          path: /tmp/digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - name: Create multi-arch manifest and push
-        run: |
-          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          digests=$(cd /tmp/digests && printf "${image}@sha256:%s " *)
-
-          docker buildx imagetools create \
-            --tag "${image}:edge" \
-            ${digests}
+    needs: test
+    uses: ./.github/workflows/docker-publish.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      push: true
+      tags: edge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,10 @@ permissions:
   contents: write
   packages: write
 
-env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_NOLOGO: true
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/deucalion
+# One run per tag; never cancel a release in flight.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   test:
@@ -21,111 +20,25 @@ jobs:
       contents: read
       packages: read
 
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      semVer: ${{ steps.gitversion.outputs.semVer }}
-      majorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}
-      major: ${{ steps.gitversion.outputs.major }}
-      minor: ${{ steps.gitversion.outputs.minor }}
-      informationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Normalize Git state for GitVersion
-        run: git checkout -B ${{ github.event.repository.default_branch }} ${{ github.sha }}
-
-      - uses: gittools/actions/gitversion/setup@v4
-        with:
-          versionSpec: '6.x'
-
-      - id: gitversion
-        uses: gittools/actions/gitversion/execute@v4
-
   docker:
-    needs: [test, version]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push by digest
-        id: build
-        uses: docker/build-push-action@v7
-        with:
-          context: ./src
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
-          build-args: |
-            VERSION=${{ needs.version.outputs.semVer }}
-            INFORMATIONAL_VERSION=${{ needs.version.outputs.informationalVersion }}
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: digest-${{ matrix.runner }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
+    needs: test
+    uses: ./.github/workflows/docker-publish.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      push: true
+      tags: |
+        {majorMinorPatch}
+        {major}.{minor}
+        {major}
+        latest
 
   release:
-    needs: [version, docker]
+    needs: docker
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: docker/setup-buildx-action@v4
-
-      - uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: actions/download-artifact@v8
-        with:
-          path: /tmp/digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - name: Create multi-arch manifest and push
-        run: |
-          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          version="${{ needs.version.outputs.majorMinorPatch }}"
-          major="${{ needs.version.outputs.major }}"
-          minor="${{ needs.version.outputs.minor }}"
-
-          digests=$(cd /tmp/digests && printf "${image}@sha256:%s " *)
-
-          docker buildx imagetools create \
-            --tag "${image}:${version}" \
-            --tag "${image}:${major}.${minor}" \
-            --tag "${image}:${major}" \
-            --tag "${image}:latest" \
-            ${digests}
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Deucalion.build.ps1
+++ b/Deucalion.build.ps1
@@ -8,15 +8,49 @@ $publishFolder = './publish'
 $BuildVersion = '0.0.0-dev'
 $InformationalVersion = '0.0.0-dev'
 
-# synopsis: Determine version using GitVersion.
+# Floor for `dotnet test`. The xunit.v3 project runs on Microsoft.Testing.Platform
+# (see global.json); if that opt-in is ever lost, `dotnet test` finds no tests
+# and exits 0. The floor turns that into a failure (exit code 9). Keep it around
+# 80% of the tests that run without DEUCALION_TESTS_NETWORK, and keep it in
+# sync with .github/workflows/build.yml.
+$MinimumExpectedTests = 101
+
+# synopsis: Determine version using GitVersion (falls back to 0.0.0-dev).
+# GitVersion comes from the repo-local tool manifest (.config/dotnet-tools.json),
+# so `dotnet tool restore` is the only prerequisite. When the tool cannot be
+# restored, or it cannot compute a version (shallow clone, git worktree, tarball
+# export...), the build still goes through with the 0.0.0-dev placeholder.
 task Version {
-    $command = Get-Command dotnet-gitversion -ErrorAction SilentlyContinue
-    if (-not $command) {
-        throw "GitVersion is not installed. Please install it using:`n`ndotnet tool install --global GitVersion.Tool"
+    $versionJson = $null
+
+    dotnet tool restore
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "'dotnet tool restore' failed (exit code $LASTEXITCODE). Using fallback version $script:BuildVersion."
     }
-    $versionJson = dotnet gitversion | ConvertFrom-Json
-    $script:BuildVersion = $versionJson.SemVer
-    $script:InformationalVersion = $versionJson.InformationalVersion
+    else {
+        # Capture stdout only. GitVersion prints its own diagnostics on stderr,
+        # which must reach the console rather than be parsed as JSON.
+        $output = dotnet gitversion /output json
+        if ($LASTEXITCODE -eq 0) {
+            try {
+                $versionJson = ($output | Out-String) | ConvertFrom-Json
+            }
+            catch {
+                Write-Warning "Could not parse GitVersion output: $_"
+            }
+        }
+        else {
+            Write-Warning "'dotnet gitversion' failed (exit code $LASTEXITCODE); see the output above."
+        }
+    }
+
+    if ($versionJson) {
+        $script:BuildVersion = $versionJson.SemVer
+        $script:InformationalVersion = $versionJson.InformationalVersion
+    }
+    else {
+        Write-Warning "GitVersion unavailable. Using fallback version $script:BuildVersion."
+    }
 
     Write-Output "Build Version: $script:BuildVersion"
     Write-Output "Informational Version: $script:InformationalVersion"
@@ -83,7 +117,11 @@ task Prod {
 # End-to-end tests are separate -- they boot both servers and take ~30s:
 #   npm --prefix ./src/ts/deucalion-ui run test:e2e
 task Test {
-    exec { dotnet test }
+    # -c Release so the trim/AOT analyzers run (src/cs/Directory.Build.props
+    # gates them on Release) and local runs see the same warnings as CI.
+    # `--` hands the option to the test host; without it `dotnet test` silently
+    # ignores --minimum-expected-tests.
+    exec { dotnet test -c Release -- --minimum-expected-tests $MinimumExpectedTests }
     exec { npm --prefix './src/ts/deucalion-ui' run test }
     exec { npm --prefix './src/ts/deucalion-ui' run lint }
 }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Simply create a configuration file, start the service, and you're done.
 - .NET 10 SDK (for development and building)
 - PowerShell (for build scripts)
 - [Invoke-Build](https://github.com/nightroman/Invoke-Build) (for build automation)
-- [GitVersion](https://gitversion.net/)
+
+[GitVersion](https://gitversion.net/) is pinned in `.config/dotnet-tools.json` and restored by the build script (`dotnet tool restore`); it does not need to be installed globally.
 
 # Usage
 
@@ -300,7 +301,9 @@ Install [`Invoke-Build`](https://github.com/nightroman/Invoke-Build).
 
 `Invoke-Build` or `Invoke-Build build` will put all artifacts in the `./publish` folder.
 
-`Invoke-Build test` runs the .NET unit tests (`dotnet test`) and the frontend unit tests (Vitest).
+The version is computed by GitVersion, restored from the repo-local tool manifest. When it cannot run (no git history, a shallow clone, a source tarball) the build warns and uses `0.0.0-dev` instead of failing.
+
+`Invoke-Build test` runs the .NET unit tests (`dotnet test -c Release`, with a minimum-expected-tests floor so a silent zero-test run fails) and the frontend unit tests (Vitest). Set `DEUCALION_TESTS_NETWORK=1` to include the DNS/ICMP tests that need the public internet; CI runs them weekly.
 
 End-to-end tests are separate -- they boot both servers themselves:
 


### PR DESCRIPTION
Closes #25
Closes #31
Closes #34

## GitVersion via tool manifest (#34)

- `.config/dotnet-tools.json` pins `GitVersion.Tool 6.8.2` (`rollForward: false`).
- `Invoke-Build Version` runs `dotnet tool restore` + `dotnet gitversion /output json`. If either fails it **warns and falls back to `0.0.0-dev`** instead of throwing, so a plain build works from a tarball / shallow clone / any machine. Both paths verified locally (worktree: real version; non-git folder: fallback, exit 0).
- CI computes the version with the same manifest (`dotnet tool restore` + `dotnet gitversion`); `gittools/actions` is gone.
- README prerequisites: GitVersion no longer needs a global install.

## Reusable `docker-publish.yml` (#31)

`edge.yml` and `release.yml` are now thin callers (`push: true`, `tags: edge` / `{majorMinorPatch}`, `{major}.{minor}`, `{major}`, `latest` -- placeholders expanded from GitVersion in the manifest step). `build.yml` calls it with `push: false`.

**Frontend is built once**, in a non-matrix `frontend` job, and injected into the per-arch image builds with `build-contexts: build-node=<dir>`. A named build context overrides the Dockerfile stage of the same name (docker docs: *"the context overrides a stage called `name` when used as `FROM ... AS name`"*), so **the Dockerfile is unchanged** and still works standalone.

The `git checkout -B <default_branch> <sha>` GitVersion workaround is kept, with a comment explaining why (detached HEAD on tag pushes + GitHubFlow branch guessing). It now runs for every caller; it is a no-op on master pushes.

## CI gaps (#25)

- `setup-node` runs before the dotnet steps (the esproj shells out to npm during `dotnet build`).
- `concurrency:` on all three workflows (PRs cancel superseded runs; `edge` serializes master pushes; `release` never cancels) and `timeout-minutes` on every job.
- `dotnet test -c Release -- --minimum-expected-tests 101` (~80% of the 127 tests that run without network). Verified locally: the flag **must** come after `--`; passed directly it is silently ignored. With a floor above the count the run fails with MTP exit code 9. The same floor is used by `Invoke-Build Test`, which now also builds Release so the trim/AOT analyzers run locally.
- New `test-windows` leg (windows-latest, .NET unit tests only).
- New `docker` job on PRs: build-only amd64 image via the reusable workflow, so trim/AOT failures surface before merge.
- Weekly `schedule` (Mon 06:00 UTC) and a `workflow_dispatch` input `network-tests` run the .NET tests with `DEUCALION_TESTS_NETWORK=1`.
  - Verified with two dispatch runs. The first showed that `PingMonitor_ReturnsUp_WhenReachable` is the only network test that fails on hosted runners (Linux **and** Windows): they cannot send ICMP echo to the internet. It is excluded on CI with xunit's `--filter-not-method` (verified under MTP locally); the second dispatch run passed with 139/139 on both legs, 0 skipped. A test-level guard would be cleaner but `PingMonitorTests.cs` is outside this PR's scope.

`actionlint 1.7.12` passes on all workflows.

Not in this PR: `build.yml` still spells out the build steps instead of calling `Invoke-Build` (issue #25 item 3). The `Build` task in the script does a self-contained publish, while CI needs separate `--no-build` test / e2e steps; unifying them is a separate change now that `Version` degrades gracefully.
