### PR TITLE
fix(engine): read-only API threshold, atomic AutoWarnTimeout, and a check-in short-circuit that never misses

### DIFF
--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -209,8 +209,10 @@ public static class Application
         // These are deliberately different numbers -- see EventHistoryCount above.
         var stats = await storage.GetStatsAsync(mn, historyCount: PullMonitor.StatsWindow, cancellationToken: cancellationToken);
 
+        // Display only: request threads must not write the live monitor's auto-WARN baseline
+        // (issue #15). EngineBackgroundService is the sole writer, via WarnThresholdPolicy.Refresh.
         applicationMonitors.Monitors.TryGetValue(mn, out var monitor);
-        var (effectiveWarn, timeout) = WarnThresholdPolicy.Refresh(monitor, stats?.Latency95, stats?.SampleCount ?? 0);
+        var (effectiveWarn, timeout) = WarnThresholdPolicy.Compute(monitor, stats?.Latency95, stats?.SampleCount ?? 0);
 
         return new(
             Name: mn,

--- a/src/cs/Deucalion.Api/Services/EngineBackgroundService.cs
+++ b/src/cs/Deucalion.Api/Services/EngineBackgroundService.cs
@@ -89,6 +89,8 @@ internal class EngineBackgroundService(
         var newStats = await storage.GetStatsAsync(mc.Name, historyCount: PullMonitor.StatsWindow, cancellationToken: cancellationToken);
         if (newStats != null)
         {
+            // The one place that writes the auto-WARN baseline: the API's GET path only computes
+            // it for display (issue #15).
             monitors.Monitors.TryGetValue(mc.Name, out var monitor);
             var (effectiveWarn, timeout) = WarnThresholdPolicy.Refresh(monitor, newStats.Latency95, newStats.SampleCount);
 

--- a/src/cs/Deucalion.Application/MonitorExtensions.cs
+++ b/src/cs/Deucalion.Application/MonitorExtensions.cs
@@ -138,10 +138,25 @@ public static class MonitorExtensions
                     // on Dispose(). Leaking one per poll grew stopToken's callback list forever
                     // (~1440/day per check-in monitor at the 60s default) and made every
                     // subsequent CreateLinkedTokenSource lock a longer list.
+                    //
+                    // The monitor must forget the source before it is disposed, or a check-in
+                    // arriving between iterations targets a disposed source and is not
+                    // short-circuited (issue #22). The finally runs before the `using` disposals.
                     using var delayCts = new CancellationTokenSource();
-                    checkInMonitor.DelayCts = delayCts;
                     using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(stopToken, delayCts.Token);
-                    await Task.Delay(delayInterval, monitor.TimeProvider, linkedCts.Token);
+                    try
+                    {
+                        // A check-in that landed while no source was armed (during the probe
+                        // above) is caught here instead of waiting out a full interval.
+                        if (checkInMonitor.ArmDelay(delayCts))
+                        {
+                            await Task.Delay(delayInterval, monitor.TimeProvider, linkedCts.Token);
+                        }
+                    }
+                    finally
+                    {
+                        checkInMonitor.DisarmDelay();
+                    }
                 }
                 else
                 {

--- a/src/cs/Deucalion.Application/WarnThresholdPolicy.cs
+++ b/src/cs/Deucalion.Application/WarnThresholdPolicy.cs
@@ -16,9 +16,30 @@ public static class WarnThresholdPolicy
     }
 
     /// <summary>
+    /// Computes the thresholds a monitor would report for the given rolling history, without
+    /// touching the monitor. This is the read-only path for request handlers (issue #15: a
+    /// <c>GET /api/monitors</c> must not reset the auto-WARN baseline of the live engine).
+    /// </summary>
+    /// <returns>
+    /// The effective WARN threshold and the hard timeout, or (null, null) when the monitor is
+    /// unknown -- e.g. a configuration entry with no corresponding live monitor.
+    /// </returns>
+    public static (TimeSpan? EffectiveWarn, TimeSpan? Timeout) Compute(PullMonitor? monitor, TimeSpan? p95, int sampleCount)
+    {
+        if (monitor is null)
+        {
+            return (null, null);
+        }
+
+        var auto = ComputeAuto(p95, sampleCount, monitor.TypeDefaultWarnTimeout);
+        return (monitor.WarnTimeout ?? auto ?? monitor.TypeDefaultWarnTimeout, monitor.Timeout);
+    }
+
+    /// <summary>
     /// Refreshes a monitor's auto-WARN baseline from its current rolling history and returns the
     /// thresholds to report. The new value persists in-process until the next probe, so subsequent
-    /// checks pick it up immediately.
+    /// checks pick it up immediately. Only the engine's event consumer may call this; every other
+    /// caller uses <see cref="Compute"/>.
     /// </summary>
     /// <returns>
     /// The effective WARN threshold and the hard timeout, or (null, null) when the monitor is

--- a/src/cs/Deucalion.Core/Monitors/PullMonitor.cs
+++ b/src/cs/Deucalion.Core/Monitors/PullMonitor.cs
@@ -32,7 +32,18 @@ public abstract class PullMonitor
     public TimeSpan? WarnTimeout { get; set; }
 
     // Computed from rolling P95; null until enough samples accumulate.
-    public TimeSpan? AutoWarnTimeout { get; set; }
+    //
+    // Written by the engine's event consumer and read by this monitor's own polling loop, on
+    // different threads. A TimeSpan? is a 16-byte struct, so a plain field can be read half
+    // written (HasValue from one write, Ticks from another -- issue #15). Storing it behind a
+    // volatile reference to an immutable boxed TimeSpan makes every read and write atomic.
+    private volatile object? _autoWarnTimeout;
+
+    public TimeSpan? AutoWarnTimeout
+    {
+        get => _autoWarnTimeout is TimeSpan value ? value : null;
+        set => _autoWarnTimeout = value;
+    }
 
     // Per-type fallback when neither manual nor auto is available. Subclasses override.
     public virtual TimeSpan TypeDefaultWarnTimeout => DefaultWarnTimeout;

--- a/src/cs/Deucalion.Network/Monitors/CheckInMonitor.cs
+++ b/src/cs/Deucalion.Network/Monitors/CheckInMonitor.cs
@@ -6,8 +6,14 @@ public sealed class CheckInMonitor : PullMonitor
 {
     public static readonly TimeSpan DefaultIntervalToDown = TimeSpan.FromMinutes(1);
 
+    // CheckIn() runs on ASP.NET request threads; QueryAsync and the delay arming run on the
+    // engine's polling loop. Everything below is shared between them and guarded by _gate
+    // (issue #22: DateTimeOffset? is a multi-word struct, so an unguarded read can tear).
+    private readonly Lock _gate = new();
     private DateTimeOffset? _lastCheckInTime;
     private MonitorResponse? _lastResponse;
+    private bool _checkInPending;
+    private CancellationTokenSource? _delayCts;
 
     // null means "no authentication" -- see the check-in endpoint in Deucalion.Api.
     public string? Secret { get; set; }
@@ -15,34 +21,80 @@ public sealed class CheckInMonitor : PullMonitor
 
     public void CheckIn(MonitorResponse? response = null)
     {
-        _lastCheckInTime = TimeProvider.GetUtcNow();
-        _lastResponse = response ?? MonitorResponse.Up();
+        CancellationTokenSource? delayCts;
+        lock (_gate)
+        {
+            // Record first, then short-circuit: whatever the polling loop is doing right now,
+            // it either sees the live delay source cancelled or finds the pending flag when it
+            // next arms a delay. Either way this check-in is reflected by the next probe.
+            _lastCheckInTime = TimeProvider.GetUtcNow();
+            _lastResponse = response ?? MonitorResponse.Up();
+            _checkInPending = true;
+            delayCts = _delayCts;
+        }
 
+        // Cancelled outside the lock: cancelling runs the delay's continuation, which may run the
+        // polling loop inline on this thread, and that loop takes _gate itself.
         try
         {
-            DelayCts?.Cancel(); // Short-circuit the polling delay
+            delayCts?.Cancel();
         }
         catch (ObjectDisposedException)
         {
-            // The polling loop already moved past this delay and disposed the source.
-            // The check-in is still recorded above; the next probe picks it up.
+            // Lost the race with DisarmDelay() + Dispose(): the loop is already past this delay
+            // and about to probe, and the check-in is recorded above, so nothing is missed.
         }
     }
 
     public override Task<MonitorResponse> QueryAsync(CancellationToken cancellationToken = default)
     {
-        if (!_lastCheckInTime.HasValue)
+        DateTimeOffset? lastCheckInTime;
+        MonitorResponse? lastResponse;
+        lock (_gate)
+        {
+            // This probe reflects every check-in recorded so far; only later ones are "pending".
+            _checkInPending = false;
+            lastCheckInTime = _lastCheckInTime;
+            lastResponse = _lastResponse;
+        }
+
+        if (!lastCheckInTime.HasValue)
             return Task.FromResult(MonitorResponse.Down());
 
-        if ((TimeProvider.GetUtcNow() - _lastCheckInTime.Value) > IntervalToDown)
+        if ((TimeProvider.GetUtcNow() - lastCheckInTime.Value) > IntervalToDown)
             return Task.FromResult(MonitorResponse.Down());
 
-        return Task.FromResult(_lastResponse ?? MonitorResponse.Up());
+        return Task.FromResult(lastResponse ?? MonitorResponse.Up());
     }
 
     /// <summary>
-    /// Set by the polling loop each iteration so <see cref="CheckIn"/> can cut the delay short.
-    /// Engine implementation detail -- the loop owns its lifetime and disposes it.
+    /// Installs the polling loop's delay source so <see cref="CheckIn"/> can cut the delay short.
+    /// Engine implementation detail -- the loop owns the source's lifetime and must call
+    /// <see cref="DisarmDelay"/> before disposing it.
     /// </summary>
-    public CancellationTokenSource? DelayCts { get; set; }
+    /// <returns>
+    /// <see langword="false"/> when a check-in arrived after the last <see cref="QueryAsync"/>,
+    /// i.e. in the window where no delay source was armed (issue #22). The caller should skip the
+    /// delay and probe again immediately; the source is armed either way.
+    /// </returns>
+    public bool ArmDelay(CancellationTokenSource delayCts)
+    {
+        lock (_gate)
+        {
+            _delayCts = delayCts;
+            return !_checkInPending;
+        }
+    }
+
+    /// <summary>
+    /// Forgets the delay source armed by <see cref="ArmDelay"/>. Call before disposing it so a
+    /// later <see cref="CheckIn"/> never targets a disposed source.
+    /// </summary>
+    public void DisarmDelay()
+    {
+        lock (_gate)
+        {
+            _delayCts = null;
+        }
+    }
 }

--- a/src/cs/Deucalion.Tests/EngineTests.cs
+++ b/src/cs/Deucalion.Tests/EngineTests.cs
@@ -175,11 +175,14 @@ public class EngineTests
         // First probe: nothing has checked in yet.
         Assert.Equal([MonitorState.Down], await harness.StateChangesAsync("m1", 1, pulse));
 
-        // Check in, then let the engine observe it.
+        // Check in, then let the engine observe it. The check-in itself cuts the delay short
+        // (issue #22), so the Up probe needs no clock advance -- and must not get one: the
+        // re-probe runs on a pool thread, and with IntervalToDown == pulse, two advances landing
+        // before it would make the check-in stale and the probe report Down (a 1-in-25 hang).
         m1.CheckIn();
         Assert.Equal(
             [MonitorState.Down, MonitorState.Up],
-            await harness.StateChangesAsync("m1", 2, pulse));
+            await harness.StateChangesAsync("m1", 2, TimeSpan.Zero));
 
         // Stop checking in: once IntervalToDown lapses it drops back to Down.
         Assert.Equal(

--- a/src/cs/Deucalion.Tests/Monitors/CheckInMonitorDelayTests.cs
+++ b/src/cs/Deucalion.Tests/Monitors/CheckInMonitorDelayTests.cs
@@ -3,6 +3,7 @@ using System.Threading.Channels;
 using Deucalion.Application;
 using Deucalion.Events;
 using Deucalion.Network.Monitors;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Deucalion.Tests.Monitors;
@@ -10,7 +11,8 @@ namespace Deucalion.Tests.Monitors;
 /// <summary>
 /// The check-in short-circuit path allocates two CancellationTokenSources per poll. Both must
 /// be disposed: the linked source registers a callback on the application-lifetime stop token,
-/// and that registration is only released on Dispose().
+/// and that registration is only released on Dispose(). And a check-in must cut the delay short
+/// no matter when it arrives relative to that per-poll lifetime (issue #22).
 /// </summary>
 public class CheckInMonitorDelayTests
 {
@@ -139,11 +141,16 @@ public class CheckInMonitorDelayTests
     [Fact]
     public async Task CheckIn_ShortCircuitsThePollingDelay()
     {
-        // A long interval means the second probe can only arrive if CheckIn() cut the delay.
+        // Regression for issue #22. A 5-minute interval on a frozen clock means the second probe
+        // can only arrive if the single CheckIn() below cut the delay short -- whether it landed
+        // on the armed delay source or in the gap between iterations. Before the fix this test
+        // had to call CheckIn() in a retry loop until one "landed on a live delay source".
         var cancellationToken = TestContext.Current.CancellationToken;
+        var time = new FakeTimeProvider();
         var monitor = new CheckInMonitor
         {
             Name = "m",
+            TimeProvider = time,
             IntervalToDown = TimeSpan.FromMinutes(5),
             IntervalWhenUp = TimeSpan.FromMinutes(5),
             IntervalWhenDown = TimeSpan.FromMinutes(5),
@@ -159,27 +166,79 @@ public class CheckInMonitorDelayTests
         var first = await ReadNextCheckedAsync(channel.Reader, stopCts.Token);
         Assert.Equal(MonitorState.Down, first.Response?.State);
 
-        // Poll CheckIn() until it lands on a live delay source, then expect a prompt second probe.
-        MonitorChecked? second = null;
-        while (second is null)
-        {
-            monitor.CheckIn();
-            try
-            {
-                using var attempt = CancellationTokenSource.CreateLinkedTokenSource(stopCts.Token);
-                attempt.CancelAfter(TimeSpan.FromMilliseconds(200));
-                second = await ReadNextCheckedAsync(channel.Reader, attempt.Token);
-            }
-            catch (OperationCanceledException) when (!stopCts.Token.IsCancellationRequested)
-            {
-                // The loop had not reached its delay yet; try again.
-            }
-        }
+        monitor.CheckIn();
 
+        // Exactly one check-in, no retries, and virtual time never advances.
+        var second = await ReadNextCheckedAsync(channel.Reader, stopCts.Token);
         Assert.Equal(MonitorState.Up, second.Response?.State);
 
         await stopCts.CancelAsync();
         try { await engineTask; } catch (OperationCanceledException) { }
+    }
+
+    // The three tests below pin the ArmDelay/DisarmDelay contract the polling loop relies on,
+    // in the exact interleavings issue #22 describes. They drive the monitor the way the loop
+    // does, so they are deterministic instead of racing a background task.
+
+    [Fact]
+    public async Task CheckIn_WhileNoDelayIsArmed_IsReportedByTheNextArmDelay()
+    {
+        // The gap between iterations: the previous delay source is gone, the next is not yet
+        // armed. The check-in must not wait out a full interval.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var monitor = new CheckInMonitor { IntervalToDown = TimeSpan.FromMinutes(5), TimeProvider = new FakeTimeProvider() };
+
+        monitor.CheckIn();
+
+        using var delayCts = new CancellationTokenSource();
+        Assert.False(monitor.ArmDelay(delayCts), "ArmDelay must report the check-in that arrived while nothing was armed.");
+        Assert.False(delayCts.IsCancellationRequested, "The source armed after the check-in must not be cancelled.");
+        monitor.DisarmDelay();
+
+        // The probe consumes the pending check-in; a fresh delay then runs normally.
+        var response = await monitor.QueryAsync(cancellationToken);
+        Assert.Equal(MonitorState.Up, response.State);
+
+        using var nextDelayCts = new CancellationTokenSource();
+        Assert.True(monitor.ArmDelay(nextDelayCts));
+        monitor.DisarmDelay();
+    }
+
+    [Fact]
+    public void CheckIn_WhileADelayIsArmed_CancelsIt()
+    {
+        var monitor = new CheckInMonitor { IntervalToDown = TimeSpan.FromMinutes(5), TimeProvider = new FakeTimeProvider() };
+
+        using var delayCts = new CancellationTokenSource();
+        Assert.True(monitor.ArmDelay(delayCts));
+
+        monitor.CheckIn();
+
+        Assert.True(delayCts.IsCancellationRequested);
+        monitor.DisarmDelay();
+    }
+
+    [Fact]
+    public async Task CheckIn_AfterTheDelayIsDisarmedAndDisposed_IsStillRecorded()
+    {
+        // The loop has disarmed and disposed its source: CheckIn() must not touch the disposed
+        // object, and the check-in must still reach the next probe.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var monitor = new CheckInMonitor { IntervalToDown = TimeSpan.FromMinutes(5), TimeProvider = new FakeTimeProvider() };
+
+        var delayCts = new CancellationTokenSource();
+        Assert.True(monitor.ArmDelay(delayCts));
+        monitor.DisarmDelay();
+        delayCts.Dispose();
+
+        monitor.CheckIn();
+
+        using var nextDelayCts = new CancellationTokenSource();
+        Assert.False(monitor.ArmDelay(nextDelayCts));
+        monitor.DisarmDelay();
+
+        var response = await monitor.QueryAsync(cancellationToken);
+        Assert.Equal(MonitorState.Up, response.State);
     }
 
     private static async Task<MonitorChecked> ReadNextCheckedAsync(ChannelReader<IMonitorEvent> reader, CancellationToken cancellationToken)

--- a/src/cs/Deucalion.Tests/Monitors/PullMonitorAutoWarnConcurrencyTests.cs
+++ b/src/cs/Deucalion.Tests/Monitors/PullMonitorAutoWarnConcurrencyTests.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics;
+using Deucalion.Monitors;
+using Deucalion.Network.Monitors;
+using Xunit;
+
+namespace Deucalion.Tests.Monitors;
+
+/// <summary>
+/// Regression for issue #15: <see cref="PullMonitor.AutoWarnTimeout"/> is written by the engine
+/// thread and read by the monitor's own polling thread. A <c>TimeSpan?</c> is a 16-byte struct,
+/// so a plain field can be observed half-written: HasValue from one write, Ticks from another.
+/// </summary>
+public class PullMonitorAutoWarnConcurrencyTests
+{
+    [Fact]
+    public void AutoWarnTimeout_ConcurrentReadsNeverObserveATornValue()
+    {
+        var monitor = new HttpMonitor { Url = new Uri("https://example.com") };
+
+        // Distinct on both halves of the struct: null flips HasValue and zeroes Ticks, the two
+        // non-null values differ in every byte of Ticks. Any interleaving of halves yields a
+        // value outside this set (e.g. HasValue=true with Ticks=0, or a mixed-bit tick count).
+        TimeSpan?[] written =
+        [
+            null,
+            TimeSpan.FromTicks(0x0101_0101_0101_0101),
+            TimeSpan.FromTicks(0x7E7E_7E7E_7E7E_7E7E),
+        ];
+        var allowed = written.ToHashSet();
+
+        // Dedicated threads and a stopwatch, deliberately: spinning on thread-pool threads and
+        // stopping them with a timer starves the pool (timer callbacks run on it too) and stalls
+        // every Task.Delay in test classes running in parallel with this one.
+        var budget = TimeSpan.FromMilliseconds(300);
+        var clock = Stopwatch.StartNew();
+
+        var writer = new Thread(() =>
+        {
+            for (var i = 0; clock.Elapsed < budget; i++)
+            {
+                monitor.AutoWarnTimeout = written[i % written.Length];
+            }
+        });
+
+        var readerCount = Math.Clamp(Environment.ProcessorCount - 1, 2, 4);
+        var reads = new long[readerCount];
+        var torn = new List<TimeSpan?>[readerCount];
+        var readers = Enumerable.Range(0, readerCount).Select(r => new Thread(() =>
+        {
+            torn[r] = [];
+            while (clock.Elapsed < budget)
+            {
+                var observed = monitor.AutoWarnTimeout;
+                reads[r]++;
+                if (!allowed.Contains(observed))
+                {
+                    torn[r].Add(observed);
+                    if (torn[r].Count >= 8) break;
+                }
+            }
+        })).ToArray();
+
+        writer.Start();
+        foreach (var reader in readers) reader.Start();
+        writer.Join();
+        foreach (var reader in readers) reader.Join();
+
+        var totalReads = reads.Sum();
+        var tornValues = torn.SelectMany(t => t).ToArray();
+
+        Assert.True(totalReads > 0, "Readers did not run.");
+        Assert.True(
+            tornValues.Length == 0,
+            $"Observed {tornValues.Length} torn AutoWarnTimeout value(s) in {totalReads} reads: " +
+            string.Join(", ", tornValues.Take(8).Select(v => v is null ? "null" : $"{v.Value.Ticks:X16}")));
+    }
+}

--- a/src/cs/Deucalion.Tests/WarnThresholdPolicyTests.cs
+++ b/src/cs/Deucalion.Tests/WarnThresholdPolicyTests.cs
@@ -1,5 +1,6 @@
 using Deucalion.Application;
 using Deucalion.Monitors;
+using Deucalion.Network.Monitors;
 using Xunit;
 
 namespace Deucalion.Tests;
@@ -55,5 +56,67 @@ public class WarnThresholdPolicyTests
             sampleCount: 100,
             typeDefault: TypeDefault);
         Assert.Equal(TypeDefault, auto);
+    }
+
+    // Enough history for the auto baseline to kick in: P95=50ms x 3 = 150ms.
+    private static readonly TimeSpan P95 = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan ExpectedAuto = TimeSpan.FromMilliseconds(50 * PullMonitor.AutoWarnMultiplier);
+    private const int EnoughSamples = 100;
+
+    [Fact]
+    public void Compute_ReportsTheAutoThreshold_WithoutWritingTheMonitor()
+    {
+        // Issue #15: GET /api/monitors runs on request threads and must not mutate the live
+        // monitor. The engine's own baseline (set here to a distinct value) has to survive.
+        var engineBaseline = TimeSpan.FromMilliseconds(999);
+        var monitor = new HttpMonitor { Url = new Uri("https://example.com"), AutoWarnTimeout = engineBaseline };
+
+        var (effectiveWarn, timeout) = WarnThresholdPolicy.Compute(monitor, P95, EnoughSamples);
+
+        Assert.Equal(ExpectedAuto, effectiveWarn);
+        Assert.Equal(monitor.Timeout, timeout);
+        Assert.Equal(engineBaseline, monitor.AutoWarnTimeout);
+    }
+
+    [Fact]
+    public void Compute_ExplicitWarnTimeoutWins()
+    {
+        var monitor = new HttpMonitor { Url = new Uri("https://example.com"), WarnTimeout = TimeSpan.FromMilliseconds(123) };
+
+        var (effectiveWarn, _) = WarnThresholdPolicy.Compute(monitor, P95, EnoughSamples);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(123), effectiveWarn);
+        Assert.Null(monitor.AutoWarnTimeout);
+    }
+
+    [Fact]
+    public void Compute_TooFewSamples_FallsBackToTypeDefault()
+    {
+        var monitor = new DnsMonitor { Host = "example.com" };
+
+        var (effectiveWarn, _) = WarnThresholdPolicy.Compute(monitor, P95, PullMonitor.AutoWarnMinSamples - 1);
+
+        Assert.Equal(DnsMonitor.DefaultDnsWarnTimeout, effectiveWarn);
+        Assert.Null(monitor.AutoWarnTimeout);
+    }
+
+    [Fact]
+    public void Compute_UnknownMonitor_ReturnsNulls()
+    {
+        Assert.Equal((null, null), WarnThresholdPolicy.Compute(null, P95, EnoughSamples));
+    }
+
+    [Fact]
+    public void Refresh_WritesTheAutoThreshold_AndReportsTheSameValuesAsCompute()
+    {
+        var monitor = new HttpMonitor { Url = new Uri("https://example.com") };
+        Assert.Null(monitor.AutoWarnTimeout);
+
+        var computed = WarnThresholdPolicy.Compute(monitor, P95, EnoughSamples);
+        var refreshed = WarnThresholdPolicy.Refresh(monitor, P95, EnoughSamples);
+
+        Assert.Equal(ExpectedAuto, monitor.AutoWarnTimeout);
+        Assert.Equal(computed, refreshed);
+        Assert.Equal(ExpectedAuto, monitor.EffectiveWarnTimeout);
     }
 }


### PR DESCRIPTION
Closes #15
Closes #22

## #15 — `GET /api/monitors` mutated live monitor state from request threads

**Root cause.** `WarnThresholdPolicy.Refresh` wrote `monitor.AutoWarnTimeout` from every `GET /api/monitors` request thread (concurrently via `Task.WhenAll`) *and* from the engine's event consumer, while the polling loop read it in `EffectiveWarnTimeout`. `TimeSpan?` is a 16-byte struct: no atomicity, no barrier.

**Fix.**
- `WarnThresholdPolicy` is split into a pure `Compute()` (derives `(EffectiveWarn, Timeout)` for display without touching the monitor) and the apply step `Refresh()`. `Application.BuildMonitorDtoAsync` now calls `Compute()`; `EngineBackgroundService` is the **only** caller of `Refresh()`.
- `PullMonitor.AutoWarnTimeout` is backed by a `volatile object?` holding an immutable boxed `TimeSpan`, so every read/write is a single atomic reference operation. Public API (`TimeSpan?` get/set) unchanged.

**Evidence.** The new stress test `PullMonitorAutoWarnConcurrencyTests.AutoWarnTimeout_ConcurrentReadsNeverObserveATornValue` (one writer cycling `null` / two bit-patterned ticks, 2–4 readers, 300 ms, dedicated threads) run against the old field:

```
Observed 184 torn AutoWarnTimeout value(s) in 3398 reads: 0000000000000000, ...
```
i.e. `HasValue == true` paired with `Ticks == 0` — a 0 ms WARN threshold. It passes with the fix (15/15 loops). `WarnThresholdPolicyTests` additionally pins that `Compute()` leaves `AutoWarnTimeout` untouched (with a distinct engine baseline in place), that explicit `warnTimeout` wins, the too-few-samples fallback, the unknown-monitor case, and that `Refresh()` writes the value and reports exactly what `Compute()` reported.

## #22 — check-ins between poll iterations missed the short-circuit; non-volatile fields

**Root cause.** `MonitorExtensions.RunAsync` disposed each per-iteration `delayCts` but left `CheckInMonitor.DelayCts` pointing at it. A `CheckIn()` arriving between iterations (or before the first delay was armed) either hit `ObjectDisposedException` or a `null` source, was not short-circuited, and waited out a full `IntervalWhenUp`. `_lastCheckInTime` / `_lastResponse` were written on request threads and read on the engine thread with no synchronisation.

**Fix.**
- `DelayCts` property replaced by `ArmDelay(cts)` / `DisarmDelay()`. The loop disarms in a `finally` *before* the `using` disposals, so a check-in never targets a disposed source. `ArmDelay()` returns `false` when a check-in arrived since the last probe (the "gap"), and the loop then skips the delay and re-probes immediately.
- `CheckIn()` records the check-in first (under a `Lock`, together with the pending flag and the delay source), then cancels whatever live delay exists outside the lock (cancelling can run the loop continuation inline, and that loop takes the lock). `QueryAsync` reads under the same lock and clears the pending flag.

**Evidence.** In `CheckInMonitorDelayTests`:
- `CheckIn_ShortCircuitsThePollingDelay` no longer loops `CheckIn()` "until it lands on a live delay source": one `CheckIn()` on a frozen `FakeTimeProvider` with 5-minute intervals must produce the next probe.
- Three deterministic tests drive the monitor exactly as the loop does, one per interleaving: check-in while nothing is armed → `ArmDelay` reports it; check-in while armed → source cancelled; check-in after disarm + dispose → no throw, still reported to the next `ArmDelay`.
- The existing registration-leak test and the ODE hammer test still pass.

### Also: `EngineTests.CheckInMonitor_GoesUpAfterACheckIn_AndBackDownWhenItStops` was hanging ~1 run in 25

Measured in isolation: **1/25 on master's code, 1/25 with the #22 fix** — so it is a harness race, not the disposed-CTS bug. After `CheckIn()` the re-probe runs as a continuation off the test thread, while `CollectUntilAsync` advances the fake clock by `pulse` (1 s) on every empty read with `IntervalToDown == pulse`; two advances before the probe make the check-in stale and the probe reports Down, so the expected Up never comes. The test now waits for the post-check-in Up with a zero step (the short-circuit needs no clock advance). Result: **0/25** in a loop of the class.

## Local verification (worktree on the rebased branch, Windows)
- `dotnet build -c Release`: 0 warnings, 0 errors (trim/AOT analyzers on).
- `dotnet test -c Release`: 172 total, 0 failed, 8 skipped — 3 consecutive full runs.
- Targeted loops after the final change: new/related classes 0/15 failures; `EngineTests` 0/25.
- e2e not run locally by design (fixed ports); relying on CI.

## Notes
- `CheckInMonitor.DelayCts` (public property) is removed in favour of `ArmDelay`/`DisarmDelay`; its only consumer was `MonitorExtensions`.
- README / CLAUDE.md: nothing they state is invalidated. If you want it recorded, the "only the engine writes the auto-WARN baseline" rule from `WarnThresholdPolicy` would fit under CLAUDE.md's notes.
