### PR TITLE
feat: make the status page discoverable by AI agents (/api/status, /api/version, llms.txt, healthcheck)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,14 @@ Change both or neither. The `Wire contract` tests in
 `MonitorState` is likewise declared in both `Deucalion.Core/MonitorState.cs` and
 `deucalion-types.ts` — the numeric values must match.
 
+The discovery payloads (`/api/status`, `/api/version`; `Models/StatusDto.cs`,
+`Models/VersionDto.cs`, served from `Endpoints/DiscoveryEndpoints.cs`) are the
+exception: long keys, string states, ISO-8601 timestamps. They exist for agents
+and humans on a one-shot fetch, the UI never reads them, and they are
+deliberately **not** mirrored in `deucalion-types.ts`. Their shape is pinned by
+the `Discovery` tests in `ApiIntegrationTests.cs`, and `public/llms.txt` must
+keep naming every endpoint (`DiscoveryHeadTests.cs` fails otherwise).
+
 ## Tests
 
 `dotnet test` needs the `global.json` opt-in to Microsoft.Testing.Platform;

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Simply create a configuration file, start the service, and you're done.
   - [`dns` Monitor](#dns-monitor)
   - [`http` Monitor](#http-monitor)
   - [`checkin` Monitor](#checkin-monitor)
+- [API](#api)
 - [Development notes](#development-notes)
   - [How to debug](#how-to-debug)
   - [Logging](#logging)
@@ -237,6 +238,31 @@ curl -X POST \
 - `secret` is **optional**. If you omit it no authentication is performed: anyone who can reach
   the endpoint can mark the monitor UP.
 - Each check-in marks the monitor UP. If none arrives within `intervalToDown`, it goes DOWN.
+
+# API
+
+Everything the page shows is available as JSON, unauthenticated, with open CORS for reads. An agent (or a human with `curl`) given only the page URL can find it without reading the JavaScript: the served HTML advertises it (`<link rel="alternate" type="application/json" href="/api/status">`, a `<meta name="description">` naming the endpoint, and a `<noscript>` pointer), `GET /` with `Accept: application/json` returns the summary directly, and `/llms.txt` is a one-screen description of the whole API.
+
+| Endpoint | Returns |
+|----------|---------|
+| `GET /api/status` | Self-describing summary: overall `status` (`operational` -- nothing down; `degraded` -- some monitors down; `outage` -- every monitor down), `updatedAt`, overall `availability` (%), one entry per monitor (`name`, `group`, `type`, `state` as `up` / `warn` / `down` / `degraded` / `unknown`, `since`, `availability`, `latencyMs`), and `links` to the other endpoints. Timestamps are ISO-8601 UTC. Start here. |
+| `GET /` with `Accept: application/json` | The same document as `/api/status` (responses carry `Vary: Accept`; a browser's Accept header still gets the HTML). |
+| `GET /api/version` | `name`, `version` (build number and git SHA), `runtime`, `startedAt` -- tells you which build a deployment is actually running. |
+| `GET /api/monitors` | Full detail per monitor as the UI consumes it: `config`, rolling `stats` (last 60 probes), and the recent `events` in compact form (`at` unix seconds, `st` numeric state, `ms` latency). |
+| `GET /api/monitors/{name}` | One monitor in the same shape. Unknown names return `404` `application/problem+json`. |
+| `GET /api/monitors/events` | Server-Sent Events stream: `MonitorChecked` (`n`, `at`, `fr`, `st`, `ms`, `ns`) on every probe and `MonitorStateChanged` (`n`, `at`, `fr`, `st`) on transitions. |
+| `POST /api/monitors/{name}/checkin` | Heartbeat for `checkin` monitors -- see [`checkin` Monitor](#checkin-monitor). |
+| `GET /llms.txt` | Plain-Markdown description of the above, for agents that look for it. |
+
+Numeric states in the compact payloads: `0` unknown, `1` down, `2` up, `3` warn, `4` degraded.
+
+```bash
+curl -s http://localhost:5000/api/status
+curl -s -H 'Accept: application/json' http://localhost:5000/
+curl -s http://localhost:5000/api/version
+```
+
+The Docker image declares a `HEALTHCHECK` that runs `Deucalion.Service --healthcheck`, which probes `/api/version` on the container's own port (`ASPNETCORE_HTTP_PORTS`, default `8080`) and exits `0` on a 2xx.
 
 # Development notes
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -61,4 +61,5 @@ VOLUME /storage
 
 EXPOSE 8080
 USER $APP_UID
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD ["./Deucalion.Service", "--healthcheck"]
 ENTRYPOINT ["./Deucalion.Service"]

--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
+using Deucalion.Api.Endpoints;
 using Deucalion.Api.Http;
 using Deucalion.Api.Models;
 using Deucalion.Api.Options;
@@ -106,6 +106,8 @@ public static class Application
         app.MapGet("/api/configuration", (DeucalionOptions options) =>
             Results.Ok(new PageConfigurationDto(options.PageTitle)));
 
+        app.MapDiscoveryEndpoints(app.Services.GetRequiredService<TimeProvider>());
+
         app.MapGet("/api/monitors/{monitorName?}", async (IStorage storage, string? monitorName, CancellationToken cancellationToken) =>
         {
             if (monitorName is null)
@@ -184,9 +186,7 @@ public static class Application
 
         // Get version info from assembly -- https://stackoverflow.com/a/64793765/33244
         //   SourceRevisionId included since .NET 8 SDK -- https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link
-        var appVersion = Assembly.GetEntryAssembly()
-            ?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-            ?.InformationalVersion;
+        var appVersion = DiscoveryEndpoints.InformationalVersion;
 
         var cmdLineArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
         logger.LogInformation("Application Version = {version}.", appVersion);

--- a/src/cs/Deucalion.Api/DeucalionJsonContext.cs
+++ b/src/cs/Deucalion.Api/DeucalionJsonContext.cs
@@ -23,4 +23,9 @@ namespace Deucalion.Api;
 [JsonSerializable(typeof(PageConfigurationDto))]
 [JsonSerializable(typeof(StatusDto))]
 [JsonSerializable(typeof(VersionDto))]
+// ProblemDetails backs every Results.Problem(...) -- the 404 for unknown monitors, the check-in
+// errors and the exception handler. Under native AOT there is no reflection fallback resolver,
+// so without this entry each of those threw NotSupportedException and surfaced as an empty 500
+// (#16). The JIT test host hides the omission; ApiIntegrationTests pins the entry instead.
+[JsonSerializable(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails))]
 internal partial class DeucalionJsonContext : JsonSerializerContext;

--- a/src/cs/Deucalion.Api/DeucalionJsonContext.cs
+++ b/src/cs/Deucalion.Api/DeucalionJsonContext.cs
@@ -21,4 +21,6 @@ namespace Deucalion.Api;
 [JsonSerializable(typeof(MonitorDto))]
 [JsonSerializable(typeof(MonitorDto[]))]
 [JsonSerializable(typeof(PageConfigurationDto))]
+[JsonSerializable(typeof(StatusDto))]
+[JsonSerializable(typeof(VersionDto))]
 internal partial class DeucalionJsonContext : JsonSerializerContext;

--- a/src/cs/Deucalion.Api/Endpoints/DiscoveryEndpoints.cs
+++ b/src/cs/Deucalion.Api/Endpoints/DiscoveryEndpoints.cs
@@ -1,0 +1,143 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Deucalion.Api.Models;
+using Deucalion.Application.Configuration;
+using Deucalion.Configuration;
+using Deucalion.Monitors;
+using Deucalion.Storage;
+
+namespace Deucalion.Api.Endpoints;
+
+/// <summary>
+/// The agent-facing door into the API: a self-describing status summary and a version endpoint.
+/// Everything here is read-only over storage -- it never touches the monitor objects, so agent
+/// polling cannot race the engine.
+/// </summary>
+public static class DiscoveryEndpoints
+{
+    public const string StatusPath = "/api/status";
+    public const string VersionPath = "/api/version";
+    public const string MonitorsPath = "/api/monitors";
+    public const string EventsPath = "/api/monitors/events";
+    public const string DocsPath = "/llms.txt";
+
+    private static readonly StatusLinksDto Links = new(
+        Self: StatusPath,
+        Monitors: MonitorsPath,
+        Events: EventsPath,
+        Version: VersionPath,
+        Docs: DocsPath
+    );
+
+    // Get version info from assembly -- https://stackoverflow.com/a/64793765/33244
+    //   SourceRevisionId included since .NET 8 SDK -- https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link
+    // The entry assembly is the host (Deucalion.Service in production); under a test host it is
+    // the test runner, so fall back to this assembly rather than reporting the runner's version.
+    public static string InformationalVersion { get; } =
+        Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(DiscoveryEndpoints).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? "unknown";
+
+    private static DateTime _startedAt;
+
+    public static IEndpointRouteBuilder MapDiscoveryEndpoints(this IEndpointRouteBuilder app, TimeProvider timeProvider)
+    {
+        _startedAt = timeProvider.GetUtcNow().UtcDateTime;
+
+        app.MapGet(StatusPath, WriteStatusAsync);
+        app.MapGet(VersionPath, WriteVersionAsync);
+
+        return app;
+    }
+
+    /// <summary>
+    /// Writes the <c>/api/status</c> payload to <paramref name="context"/>. Public so the
+    /// service host can serve the same document for <c>GET /</c> with <c>Accept: application/json</c>.
+    /// </summary>
+    public static async Task WriteStatusAsync(HttpContext context)
+    {
+        var storage = context.RequestServices.GetRequiredService<IStorage>();
+        var configuration = context.RequestServices.GetRequiredService<ApplicationConfiguration>();
+        var timeProvider = context.RequestServices.GetRequiredService<TimeProvider>();
+
+        var status = await BuildStatusAsync(storage, configuration, timeProvider, context.RequestAborted);
+        await Results.Json(status, DeucalionJsonContext.Default.StatusDto).ExecuteAsync(context);
+    }
+
+    private static Task WriteVersionAsync(HttpContext context)
+    {
+        var version = new VersionDto(
+            Name: "Deucalion",
+            Version: InformationalVersion,
+            Runtime: RuntimeInformation.FrameworkDescription,
+            StartedAt: _startedAt
+        );
+        return Results.Json(version, DeucalionJsonContext.Default.VersionDto).ExecuteAsync(context);
+    }
+
+    internal static async Task<StatusDto> BuildStatusAsync(IStorage storage, ApplicationConfiguration configuration, TimeProvider timeProvider, CancellationToken cancellationToken)
+    {
+        var monitors = await Task.WhenAll(configuration.Monitors.Select(kvp => BuildMonitorAsync(storage, kvp.Key, kvp.Value, cancellationToken)));
+
+        // Monitors that have never been probed do not vote: with no evidence either way they
+        // must neither drag the summary into "degraded" nor mask a real outage.
+        var known = monitors.Where(m => m.State != "unknown").ToArray();
+        var down = known.Count(m => m.State == "down");
+        var status = down switch
+        {
+            0 => "operational",
+            _ when down == known.Length => "outage",
+            _ => "degraded",
+        };
+
+        var availabilities = monitors.Where(m => m.Availability is not null).Select(m => m.Availability!.Value).ToArray();
+
+        return new StatusDto(
+            Status: status,
+            UpdatedAt: timeProvider.GetUtcNow().UtcDateTime,
+            Availability: availabilities.Length > 0 ? Math.Round(availabilities.Average(), 2) : null,
+            Monitors: monitors,
+            Links: Links
+        );
+    }
+
+    private static async Task<StatusMonitorDto> BuildMonitorAsync(IStorage storage, string name, PullMonitorConfiguration configuration, CancellationToken cancellationToken)
+    {
+        // Same rolling window as /api/monitors, so the two endpoints agree on availability.
+        var stats = await storage.GetStatsAsync(name, historyCount: PullMonitor.StatsWindow, cancellationToken: cancellationToken);
+        var events = (await storage.GetLastEventsAsync(name, count: PullMonitor.StatsWindow, cancellationToken: cancellationToken)).ToArray();
+
+        var state = stats?.LastState ?? MonitorState.Unknown;
+
+        // `since`: the oldest event of the trailing run in the current state. Bounded by the
+        // window, so a long-stable monitor reports "at least since".
+        DateTime? since = null;
+        int? latencyMs = null;
+        if (events.Length > 0)
+        {
+            // Newest first.
+            latencyMs = (int?)events[0].ResponseTime?.TotalMilliseconds;
+            var run = events.TakeWhile(e => e.State == state).ToArray();
+            since = run.Length > 0 ? run[^1].At.UtcDateTime : null;
+        }
+
+        return new StatusMonitorDto(
+            Name: name,
+            Group: configuration.Group,
+            Type: MonitorConfigurationDto.From(configuration).Type,
+            State: StateName(state),
+            Since: since,
+            Availability: stats is null ? null : Math.Round(stats.Availability, 2),
+            LatencyMs: latencyMs
+        );
+    }
+
+    internal static string StateName(MonitorState state) => state switch
+    {
+        MonitorState.Up => "up",
+        MonitorState.Warn => "warn",
+        MonitorState.Down => "down",
+        MonitorState.Degraded => "degraded",
+        _ => "unknown",
+    };
+}

--- a/src/cs/Deucalion.Api/Models/StatusDto.cs
+++ b/src/cs/Deucalion.Api/Models/StatusDto.cs
@@ -1,0 +1,33 @@
+namespace Deucalion.Api.Models;
+
+/// <summary>
+/// Self-describing summary served by <c>GET /api/status</c> (and by <c>GET /</c> under
+/// <c>Accept: application/json</c>). Long keys, string states and ISO-8601 timestamps on purpose:
+/// this payload is for agents and humans on a one-shot discovery fetch, not for the UI, so it
+/// is NOT mirrored in <c>deucalion-types.ts</c>.
+/// </summary>
+public record StatusDto(
+    string Status,
+    DateTime UpdatedAt,
+    double? Availability,
+    StatusMonitorDto[] Monitors,
+    StatusLinksDto Links
+);
+
+public record StatusMonitorDto(
+    string Name,
+    string? Group,
+    string Type,
+    string State,
+    DateTime? Since,
+    double? Availability,
+    int? LatencyMs
+);
+
+public record StatusLinksDto(
+    string Self,
+    string Monitors,
+    string Events,
+    string Version,
+    string Docs
+);

--- a/src/cs/Deucalion.Api/Models/VersionDto.cs
+++ b/src/cs/Deucalion.Api/Models/VersionDto.cs
@@ -1,0 +1,12 @@
+namespace Deucalion.Api.Models;
+
+/// <summary>
+/// Served by <c>GET /api/version</c>: identifies the running build (the assembly's informational
+/// version, which carries the git SHA) so a deployed instance can be told apart from master.
+/// </summary>
+public record VersionDto(
+    string Name,
+    string Version,
+    string Runtime,
+    DateTime StartedAt
+);

--- a/src/cs/Deucalion.Service/Program.cs
+++ b/src/cs/Deucalion.Service/Program.cs
@@ -1,7 +1,15 @@
 ﻿using Deucalion.Api;
+using Deucalion.Api.Endpoints;
 using Deucalion.Application.Configuration;
 using Deucalion.Service;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+
+// Docker HEALTHCHECK entry point: probe the running instance and exit, never build a host.
+if (args.Contains("--healthcheck", StringComparer.Ordinal))
+{
+    using var handler = new SocketsHttpHandler();
+    return await RunHealthCheckAsync(handler, Environment.GetEnvironmentVariable("ASPNETCORE_HTTP_PORTS"), TimeSpan.FromSeconds(3));
+}
 
 try
 {
@@ -41,4 +49,27 @@ catch (ConfigurationErrorException ex)
 
 return 0;
 
-public partial class Program;
+public partial class Program
+{
+    /// <summary>
+    /// <c>--healthcheck</c>: GET <c>/api/version</c> on the first port of
+    /// <paramref name="httpPorts"/> (<c>ASPNETCORE_HTTP_PORTS</c>, default 8080) and report 0 on
+    /// a 2xx, 1 on anything else -- a non-2xx, a timeout, or no listener at all. Plain
+    /// <see cref="HttpClient"/> only: this runs inside the AOT-published binary.
+    /// </summary>
+    public static async Task<int> RunHealthCheckAsync(HttpMessageHandler handler, string? httpPorts, TimeSpan timeout)
+    {
+        var port = httpPorts?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).FirstOrDefault() ?? "8080";
+
+        using var client = new HttpClient(handler, disposeHandler: false) { Timeout = timeout };
+        try
+        {
+            using var response = await client.GetAsync($"http://localhost:{port}{DiscoveryEndpoints.VersionPath}");
+            return response.IsSuccessStatusCode ? 0 : 1;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or OperationCanceledException)
+        {
+            return 1;
+        }
+    }
+}

--- a/src/cs/Deucalion.Service/WebApplicationExtensions.cs
+++ b/src/cs/Deucalion.Service/WebApplicationExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System.Security.Cryptography;
 using System.Text;
 using System.Web;
+using Deucalion.Api.Endpoints;
 using Deucalion.Api.Options;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Deucalion.Service;
@@ -117,6 +119,22 @@ internal static class WebApplicationExtensions
                         return;
                     }
 
+                    // Content negotiation: the same URL a human gets serves agents the
+                    // self-describing JSON summary when they ask for it. Both variants
+                    // must carry Vary: Accept, or a cache could hand one client the other's.
+                    context.Response.Headers.Vary = "Accept";
+                    if (PrefersJson(context.Request.Headers.Accept))
+                    {
+                        if (HttpMethods.IsHead(method))
+                        {
+                            context.Response.ContentType = "application/json";
+                            return;
+                        }
+
+                        await DiscoveryEndpoints.WriteStatusAsync(context);
+                        return;
+                    }
+
                     // Conditional GET: return 304 if client has current version
                     var ifNoneMatch = context.Request.Headers.IfNoneMatch.ToString();
                     if (ifNoneMatch == "*" || ifNoneMatch.Contains(etag))
@@ -176,6 +194,64 @@ internal static class WebApplicationExtensions
         return wildcard is not null && (wildcard.Quality ?? 1) > 0;
     }
 
+    /// <summary>
+    /// Whether the Accept header ranks <c>application/json</c> strictly above <c>text/html</c>.
+    /// A browser's Accept (<c>text/html,...,*/*;q=0.8</c>) and curl's bare <c>*/*</c> both keep
+    /// HTML; only a client that asks for JSON by name (or with a higher q) gets it.
+    /// </summary>
+    internal static bool PrefersJson(StringValues accept)
+    {
+        if (!MediaTypeHeaderValue.TryParseList(accept, out var accepted))
+        {
+            return false;
+        }
+
+        return Quality(accepted, "application", "json") > Quality(accepted, "text", "html");
+    }
+
+    /// <summary>
+    /// The q-value the most specific matching range assigns to <paramref name="type"/>/<paramref name="subType"/>
+    /// (exact beats <c>type/*</c> beats <c>*/*</c>); 0 when nothing matches.
+    /// </summary>
+    private static double Quality(IList<MediaTypeHeaderValue> accepted, string type, string subType)
+    {
+        var best = 0.0;
+        var bestSpecificity = -1;
+
+        foreach (var range in accepted)
+        {
+            int specificity;
+            if (range.MatchesAllTypes)
+            {
+                specificity = 0;
+            }
+            else if (!range.Type.Equals(type, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            else if (range.MatchesAllSubTypes)
+            {
+                specificity = 1;
+            }
+            else if (range.SubType.Equals(subType, StringComparison.OrdinalIgnoreCase))
+            {
+                specificity = 2;
+            }
+            else
+            {
+                continue;
+            }
+
+            if (specificity > bestSpecificity)
+            {
+                bestSpecificity = specificity;
+                best = range.Quality ?? 1;
+            }
+        }
+
+        return best;
+    }
+
     private static void SetImmutableCacheHeaders(HttpResponse response)
     {
         var headers = response.GetTypedHeaders();
@@ -198,8 +274,23 @@ internal static class WebApplicationExtensions
         var options = app.Services.GetRequiredService<DeucalionOptions>();
         var htmlTitle = HttpUtility.HtmlEncode(options.PageTitle);
 
+        // Head metadata is what survives an agent's text-extraction pipeline (empirically: the
+        // title and meta tags of the served page made it through; the body did not), so the
+        // API is advertised here, in the initial payload, not by anything JS renders later.
+        var description = HttpUtility.HtmlEncode(
+            $"{options.PageTitle} — live service status. Machine-readable status at {DiscoveryEndpoints.StatusPath}; docs at {DiscoveryEndpoints.DocsPath}");
+
+        var head =
+            $"<title>{htmlTitle}</title>\n" +
+            $"    <link rel=\"alternate\" type=\"application/json\" href=\"{DiscoveryEndpoints.StatusPath}\" />\n" +
+            $"    <meta name=\"description\" content=\"{description}\" />";
+
+        var noscript =
+            $"<noscript><p>This page needs JavaScript. Machine-readable status: <a href=\"{DiscoveryEndpoints.StatusPath}\">{DiscoveryEndpoints.StatusPath}</a></p></noscript>";
+
         var indexContent = File.ReadAllText(indexFile);
         return indexContent
-            .Replace("<!-- $DEUCALION__PAGETITLE -->", $"<title>{htmlTitle}</title>");
+            .Replace("<!-- $DEUCALION__PAGETITLE -->", head)
+            .Replace("<!-- $DEUCALION__NOSCRIPT -->", noscript);
     }
 }

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -274,4 +274,138 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
             builder.UseEnvironment("Development");
         }
     }
+
+    // --- Discovery: /api/status and /api/version (#35, #16) -----------------------------------
+
+    [Fact]
+    public async Task GetStatus_ReturnsSelfDescribingSummary()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        // checkin-main: down, then up twice -> state "up" since the first up.
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now.AddSeconds(1), MonitorState.Up, TimeSpan.FromMilliseconds(120), null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now.AddSeconds(2), MonitorState.Up, TimeSpan.FromMilliseconds(123), null), TestContext.Current.CancellationToken);
+        // web-main: down -> the summary is "degraded" (some, not all, down).
+        await storage.SaveEventAsync("web-main", new StoredEvent(now.AddSeconds(2), MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+
+        using var client = _factory.CreateClient();
+        using var response = await client.GetAsync("/api/status", TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+
+        Assert.Equal("degraded", payload.GetProperty("status").GetString());
+        Assert.True(payload.GetProperty("availability").GetDouble() is > 0 and <= 100);
+
+        // ISO-8601 UTC, not unix seconds.
+        var updatedAt = payload.GetProperty("updatedAt").GetString()!;
+        Assert.EndsWith("Z", updatedAt, StringComparison.Ordinal);
+        Assert.True(DateTimeOffset.TryParse(updatedAt, out _));
+
+        var monitors = payload.GetProperty("monitors").EnumerateArray().ToDictionary(m => m.GetProperty("name").GetString()!);
+        Assert.Equal(["web-main", "checkin-main", "checkin-open"], monitors.Keys); // configuration order
+
+        var checkIn = monitors["checkin-main"];
+        Assert.Equal("Main", checkIn.GetProperty("group").GetString());
+        Assert.Equal("checkin", checkIn.GetProperty("type").GetString());
+        Assert.Equal("up", checkIn.GetProperty("state").GetString());
+        Assert.Equal(123, checkIn.GetProperty("latencyMs").GetInt32());
+        Assert.True(checkIn.GetProperty("availability").GetDouble() > 0);
+        // `since` is the start of the trailing "up" run: the first up, not the last, not the down.
+        Assert.Equal(now.AddSeconds(1).UtcDateTime, DateTime.Parse(checkIn.GetProperty("since").GetString()!, null, System.Globalization.DateTimeStyles.AdjustToUniversal), TimeSpan.FromMilliseconds(1));
+
+        var web = monitors["web-main"];
+        Assert.Equal("http", web.GetProperty("type").GetString());
+        Assert.Equal("down", web.GetProperty("state").GetString());
+        Assert.False(web.TryGetProperty("latencyMs", out _), "a failed probe has no latency; the key must be omitted, not null");
+
+        var links = payload.GetProperty("links");
+        Assert.Equal("/api/status", links.GetProperty("self").GetString());
+        Assert.Equal("/api/monitors", links.GetProperty("monitors").GetString());
+        Assert.Equal("/api/monitors/events", links.GetProperty("events").GetString());
+        Assert.Equal("/api/version", links.GetProperty("version").GetString());
+        Assert.Equal("/llms.txt", links.GetProperty("docs").GetString());
+
+        // The advertised REST links resolve (the SSE stream and llms.txt are covered elsewhere).
+        foreach (var rel in new[] { "monitors", "version" })
+        {
+            using var linked = await client.GetAsync(links.GetProperty(rel).GetString(), TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, linked.StatusCode);
+        }
+    }
+
+    [Fact]
+    public async Task GetStatus_AllDown_ReportsOutage()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        foreach (var name in new[] { "web-main", "checkin-main", "checkin-open" })
+        {
+            await storage.SaveEventAsync(name, new StoredEvent(now, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        }
+
+        using var client = _factory.CreateClient();
+        var payload = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+
+        Assert.Equal("outage", payload.GetProperty("status").GetString());
+        Assert.All(payload.GetProperty("monitors").EnumerateArray(), m => Assert.Equal("down", m.GetProperty("state").GetString()));
+    }
+
+    [Fact]
+    public async Task GetStatus_AllUpOrWarn_ReportsOperational()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        await storage.SaveEventAsync("web-main", new StoredEvent(now, MonitorState.Warn, TimeSpan.FromSeconds(2), null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now, MonitorState.Up, TimeSpan.FromMilliseconds(5), null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-open", new StoredEvent(now, MonitorState.Up, TimeSpan.FromMilliseconds(5), null), TestContext.Current.CancellationToken);
+
+        using var client = _factory.CreateClient();
+        var payload = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+
+        Assert.Equal("operational", payload.GetProperty("status").GetString());
+        Assert.Equal("warn", payload.GetProperty("monitors")[0].GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public async Task GetStatus_IsReadOnly_DoesNotMutateMonitors()
+    {
+        // Agents poll this endpoint; it must never touch the monitor objects (#15).
+        using var client = _factory.CreateClient();
+        var monitors = _factory.Services.GetRequiredService<Deucalion.Application.Configuration.ApplicationMonitors>().Monitors;
+        var before = monitors.Values.Select(m => (m.Name, m.AutoWarnTimeout, m.WarnTimeout)).ToArray();
+
+        using var response = await client.GetAsync("/api/status", TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var after = monitors.Values.Select(m => (m.Name, m.AutoWarnTimeout, m.WarnTimeout)).ToArray();
+        Assert.Equal(before, after);
+    }
+
+    [Fact]
+    public async Task GetVersion_IdentifiesTheRunningBuild()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/version", TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Deucalion", payload.GetProperty("name").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(payload.GetProperty("version").GetString()));
+        Assert.StartsWith(".NET ", payload.GetProperty("runtime").GetString(), StringComparison.Ordinal);
+
+        var startedAt = DateTimeOffset.Parse(payload.GetProperty("startedAt").GetString()!);
+        Assert.InRange(startedAt, DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow);
+    }
 }

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -408,4 +408,14 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         var startedAt = DateTimeOffset.Parse(payload.GetProperty("startedAt").GetString()!);
         Assert.InRange(startedAt, DateTimeOffset.UtcNow.AddMinutes(-5), DateTimeOffset.UtcNow);
     }
+
+    [Fact]
+    public void JsonContext_DeclaresProblemDetails_ForAotProblemResponses()
+    {
+        // #16: the deployed (native AOT) instance returned an empty 500 for unknown monitor names
+        // because Results.Problem(...) could not serialize ProblemDetails -- no reflection resolver
+        // exists under AOT and the source-generated context did not declare the type. This JIT
+        // host cannot reproduce the failure, so pin the declaration directly.
+        Assert.NotNull(Deucalion.Api.DeucalionJsonContext.Default.GetTypeInfo(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails)));
+    }
 }

--- a/src/cs/Deucalion.Tests/Service/DiscoveryHeadTests.cs
+++ b/src/cs/Deucalion.Tests/Service/DiscoveryHeadTests.cs
@@ -1,0 +1,355 @@
+extern alias Service;
+
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+namespace Deucalion.Tests.Service;
+
+/// <summary>
+/// The agent-discoverability surface of the service host (#35): the API advertised from the
+/// served <c>index.html</c>, content negotiation on <c>/</c>, <c>/llms.txt</c>, and the
+/// <c>--healthcheck</c> probe. Same fixture shape as <see cref="ServiceHostTests"/>.
+/// </summary>
+[Collection(ProcessEnvironmentCollection.Name)]
+public sealed class DiscoveryHeadTests : IAsyncLifetime
+{
+    private const string ConfigurationFileEnvVar = "Deucalion__ConfigurationFile";
+    private const string StoragePathEnvVar = "Deucalion__StoragePath";
+    private const string PageTitleEnvVar = "Deucalion__PageTitle";
+
+    private const string PageTitle = "Acme <Status>";
+
+    // The real index.html carries both placeholders; the template mirrors their positions.
+    private const string IndexTemplate =
+        """
+        <!doctype html>
+        <html><head><meta charset="utf-8"><!-- $DEUCALION__PAGETITLE --></head>
+        <body><div id="root"></div><!-- $DEUCALION__NOSCRIPT --></body></html>
+        """;
+
+    private const string BrowserAccept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
+
+    private readonly string _tempPath;
+    private readonly ServiceFactory _factory;
+
+    public DiscoveryHeadTests()
+    {
+        _tempPath = Path.Combine(Path.GetTempPath(), $"Deucalion.Tests.Discovery_{Guid.NewGuid()}");
+        var webRootPath = Path.Combine(_tempPath, "wwwroot");
+        Directory.CreateDirectory(webRootPath);
+
+        File.WriteAllText(Path.Combine(webRootPath, "index.html"), IndexTemplate);
+
+        // Serve the real llms.txt from the repository, not a stand-in: the test must fail if
+        // the shipped file stops naming an endpoint.
+        File.Copy(FindRepoFile(Path.Combine("src", "ts", "deucalion-ui", "public", "llms.txt")), Path.Combine(webRootPath, "llms.txt"));
+
+        var configurationPath = Path.Combine(_tempPath, "deucalion.yaml");
+        File.WriteAllText(configurationPath,
+            """
+            monitors:
+              checkin-only: !checkin
+                group: Main
+            """);
+
+        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, configurationPath);
+        Environment.SetEnvironmentVariable(StoragePathEnvVar, Path.Combine(_tempPath, "storage"));
+        Environment.SetEnvironmentVariable(PageTitleEnvVar, PageTitle);
+
+        _factory = new ServiceFactory(_tempPath);
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+
+        Environment.SetEnvironmentVariable(PageTitleEnvVar, null);
+        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, null);
+        Environment.SetEnvironmentVariable(StoragePathEnvVar, null);
+
+        TestPaths.DeleteWithRetry(_tempPath);
+    }
+
+    // --- Head injection -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetIndex_AdvertisesApiInHeadAndNoscript()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/", TestContext.Current.CancellationToken);
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+
+        // Head: title, alternate link and description -- the parts an extraction pipeline keeps.
+        var head = html[..html.IndexOf("</head>", StringComparison.Ordinal)];
+        Assert.Contains("<title>Acme &lt;Status&gt;</title>", head, StringComparison.Ordinal);
+        Assert.Contains("<link rel=\"alternate\" type=\"application/json\" href=\"/api/status\" />", head, StringComparison.Ordinal);
+        Assert.Contains("<meta name=\"description\" content=\"Acme &lt;Status&gt; — live service status. Machine-readable status at /api/status; docs at /llms.txt\" />", head, StringComparison.Ordinal);
+
+        // Body: the noscript pointer sits inside <body>, after #root.
+        var body = html[html.IndexOf("<body>", StringComparison.Ordinal)..];
+        Assert.Contains("<noscript>", body, StringComparison.Ordinal);
+        Assert.Contains("<a href=\"/api/status\">/api/status</a>", body, StringComparison.Ordinal);
+        Assert.True(body.IndexOf("id=\"root\"", StringComparison.Ordinal) < body.IndexOf("<noscript>", StringComparison.Ordinal));
+
+        Assert.DoesNotContain("$DEUCALION__", html, StringComparison.Ordinal);
+        Assert.DoesNotContain(PageTitle, html, StringComparison.Ordinal); // never raw, always encoded
+    }
+
+    // --- Content negotiation on / -------------------------------------------------------------
+
+    [Theory]
+    [InlineData("application/json")]
+    [InlineData("application/json, text/html;q=0.9")]
+    [InlineData("text/html;q=0.5, application/*")]
+    [InlineData("application/json;q=0.9, */*;q=0.1")]
+    public async Task GetIndex_AcceptPrefersJson_ReturnsStatusDocument(string accept)
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await SendAsync(client, HttpMethod.Get, accept);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("Accept", response.Headers.Vary);
+        Assert.Null(response.Headers.ETag); // the HTML's ETag must not leak onto the JSON variant
+
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        Assert.Equal("/api/status", payload.GetProperty("links").GetProperty("self").GetString());
+        Assert.Equal("checkin-only", payload.GetProperty("monitors")[0].GetProperty("name").GetString());
+
+        // Same document as the endpoint itself. Compare the stable parts only: the engine's
+        // start-up probe of checkin-only may land between the two requests and flip its state.
+        var direct = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+        Assert.Equal(direct.GetProperty("links").GetRawText(), payload.GetProperty("links").GetRawText());
+        Assert.Equal(
+            direct.GetProperty("monitors").EnumerateArray().Select(m => m.GetProperty("name").GetString()),
+            payload.GetProperty("monitors").EnumerateArray().Select(m => m.GetProperty("name").GetString()));
+    }
+
+    [Theory]
+    [InlineData(BrowserAccept)]
+    [InlineData("*/*")]
+    [InlineData("text/html, application/json")] // a tie keeps HTML
+    [InlineData("text/*")]
+    [InlineData("application/json;q=0")]
+    [InlineData("not a media type")]
+    [InlineData(null)]
+    public async Task GetIndex_AcceptDoesNotPreferJson_ReturnsHtml(string? accept)
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await SendAsync(client, HttpMethod.Get, accept);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("Accept", response.Headers.Vary);
+        Assert.NotNull(response.Headers.ETag);
+
+        var html = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        Assert.StartsWith("<!doctype html>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetIndex_AcceptJson_IgnoresHtmlETag()
+    {
+        // The conditional-GET shortcut belongs to the HTML variant only: a client holding the
+        // HTML ETag but asking for JSON must get the JSON, not a 304.
+        using var client = _factory.CreateClient();
+
+        using var initial = await client.GetAsync("/", TestContext.Current.CancellationToken);
+        var etag = initial.Headers.ETag!;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        request.Headers.IfNoneMatch.Add(etag);
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task HeadIndex_AcceptJson_ReturnsJsonHeadersWithoutBody()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await SendAsync(client, HttpMethod.Head, "application/json");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task PostIndex_AcceptJson_StillReturns405()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await SendAsync(client, HttpMethod.Post, "application/json");
+
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+
+    // --- /llms.txt ----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetLlmsTxt_ServesTheShippedFile_NamingEveryEndpoint()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/llms.txt", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
+
+        var text = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        foreach (var path in new[] { "/api/status", "/api/monitors", "/api/monitors/{name}", "/api/monitors/events", "/api/version", "/api/monitors/{name}/checkin" })
+        {
+            Assert.Contains(path, text, StringComparison.Ordinal);
+        }
+
+        // The SSE short keys, as documented for agents.
+        foreach (var key in new[] { "\"n\"", "\"at\"", "\"fr\"", "\"st\"", "\"ms\"", "\"ns\"" })
+        {
+            Assert.Contains(key, text, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("deucalion-checkin-secret", text, StringComparison.Ordinal);
+    }
+
+    // --- --healthcheck ------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("8080")]
+    [InlineData("8080;8081")]
+    [InlineData(" 9000 ")]
+    [InlineData(null)]
+    public async Task HealthCheck_AgainstRunningHost_ReturnsZero(string? httpPorts)
+    {
+        // TestServer's handler answers any host:port in-process, so this exercises the real
+        // probe -- URL building, the /api/version round trip, and the 2xx check.
+        using var handler = _factory.Server.CreateHandler();
+
+        var exitCode = await Service::Program.RunHealthCheckAsync(handler, httpPorts, TimeSpan.FromSeconds(3));
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Found)]
+    public async Task HealthCheck_NonSuccessStatus_ReturnsOne(HttpStatusCode statusCode)
+    {
+        using var handler = new StubHandler(_ => new HttpResponseMessage(statusCode));
+
+        var exitCode = await Service::Program.RunHealthCheckAsync(handler, "8080", TimeSpan.FromSeconds(3));
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task HealthCheck_ProbesVersionEndpointOnConfiguredPort()
+    {
+        Uri? requested = null;
+        using var handler = new StubHandler(request =>
+        {
+            requested = request.RequestUri;
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        await Service::Program.RunHealthCheckAsync(handler, "9090;9091", TimeSpan.FromSeconds(3));
+
+        Assert.Equal(new Uri("http://localhost:9090/api/version"), requested);
+    }
+
+    [Fact]
+    public async Task HealthCheck_NoListener_ReturnsOne()
+    {
+        // A port nothing listens on: the connection is refused, which must read as unhealthy
+        // rather than crash the probe.
+        using var handler = new SocketsHttpHandler();
+
+        var exitCode = await Service::Program.RunHealthCheckAsync(handler, FreePort().ToString(), TimeSpan.FromSeconds(3));
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task HealthCheck_Timeout_ReturnsOne()
+    {
+        using var handler = new StubHandler(async (_, ct) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+
+        var exitCode = await Service::Program.RunHealthCheckAsync(handler, "8080", TimeSpan.FromMilliseconds(200));
+
+        Assert.Equal(1, exitCode);
+    }
+
+    // --- Helpers ------------------------------------------------------------------------------
+
+    private static Task<HttpResponseMessage> SendAsync(HttpClient client, HttpMethod method, string? accept)
+    {
+        var request = new HttpRequestMessage(method, "/");
+        if (accept is not null)
+        {
+            request.Headers.TryAddWithoutValidation("Accept", accept);
+        }
+
+        return client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+
+    private static string FindRepoFile(string relativePath)
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, relativePath);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new FileNotFoundException($"'{relativePath}' not found above '{AppContext.BaseDirectory}'.");
+    }
+
+    private static int FreePort()
+    {
+        using var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond) : HttpMessageHandler
+    {
+        public StubHandler(Func<HttpRequestMessage, HttpResponseMessage> respond)
+            : this((request, _) => Task.FromResult(respond(request)))
+        {
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            respond(request, cancellationToken);
+    }
+
+    private sealed class ServiceFactory(string contentRoot) : WebApplicationFactory<Service::Program>
+    {
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("Production");
+            builder.UseContentRoot(contentRoot);
+        }
+    }
+}

--- a/src/ts/deucalion-ui/index.html
+++ b/src/ts/deucalion-ui/index.html
@@ -81,6 +81,7 @@
       <img id="splash-icon" src="/assets/deucalion-icon.svg" alt="" />
     </div>
     <div id="root"></div>
+    <!-- $DEUCALION__NOSCRIPT -->
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/src/ts/deucalion-ui/public/llms.txt
+++ b/src/ts/deucalion-ui/public/llms.txt
@@ -1,0 +1,17 @@
+# Deucalion status page
+
+> A minimal service-status page. The JSON API below is public: no authentication, no API key, CORS open for reads.
+
+## Endpoints (all GET, all JSON)
+
+- `/api/status` — self-describing summary: `status` (`operational` | `degraded` | `outage`), `updatedAt` (ISO-8601 UTC), `availability` (%), and `monitors[]` with `name`, `group`, `type`, `state` (`up` | `warn` | `down` | `degraded` | `unknown`), `since`, `availability`, `latencyMs`. Start here. `GET /` with `Accept: application/json` returns the same document.
+- `/api/monitors` — full detail per monitor: `config`, rolling `stats`, and the recent `events[]` in the compact form `{ "at": <unix seconds>, "st": <state>, "ms": <latency> }` where `st` is 0 unknown, 1 down, 2 up, 3 warn, 4 degraded.
+- `/api/monitors/{name}` — one monitor in the same shape; unknown names return 404 `application/problem+json`.
+- `/api/version` — `name`, `version` (build + git SHA), `runtime`, `startedAt`.
+- `/api/monitors/events` — Server-Sent Events stream. Event `MonitorChecked`: `{ "n": name, "at": unix seconds, "fr": previous state, "st": state, "ms": latency, "ns": new stats }`. Event `MonitorStateChanged`: `{ "n", "at", "fr", "st" }`. Opens with a `: connected` comment.
+
+## Writes
+
+- `POST /api/monitors/{name}/checkin` — heartbeat for `checkin`-type monitors. Send the monitor's secret (if configured) in the `deucalion-checkin-secret` header. Returns 200; 401 on a wrong secret; 400 if the monitor is not a check-in monitor.
+
+Source and documentation: https://github.com/fdcastel/Deucalion


### PR DESCRIPTION
Closes #35
Closes #16

## Summary

An agent given nothing but the status-page URL can now find and read the API without scraping JS.

**API (`Deucalion.Api`)**
- `GET /api/status` — self-describing summary: long keys, string states (`up`/`warn`/`down`/`degraded`/`unknown`), ISO-8601 UTC timestamps, overall `status` (`operational` / `degraded` / `outage`), overall `availability`, per-monitor `since` / `availability` / `latencyMs`, and a `links` block to the rest of the API. Read-only over storage (same 60-probe window as `/api/monitors`); it never touches the monitor objects, so agent polling cannot race the engine (#15).
- `GET /api/version` — `name`, `version` (informational version: build + git SHA), `runtime`, `startedAt`.
- New DTOs in `Models/StatusDto.cs`, `Models/VersionDto.cs`; endpoints in `Endpoints/DiscoveryEndpoints.cs`; two `[JsonSerializable]` entries appended. Source-generated JSON only (`Results.Json(value, DeucalionJsonContext.Default.X)`) — the Release build reports zero IL/AOT warnings.
- `Application.cs`: one `app.MapDiscoveryEndpoints(...)` call after `/api/configuration`; the version lookup that was logged at startup now comes from `DiscoveryEndpoints.InformationalVersion`.

**Service host (`Deucalion.Service`)**
- `BuildIndexContent` injects, next to the title: `<link rel="alternate" type="application/json" href="/api/status">`, `<meta name="description" content="<PageTitle> — live service status. Machine-readable status at /api/status; docs at /llms.txt">`, and a `<noscript>` pointer in `<body>` (new `<!-- $DEUCALION__NOSCRIPT -->` placeholder in `index.html`).
- Content negotiation on `/`: an `Accept` that ranks `application/json` strictly above `text/html` (parsed with `MediaTypeHeaderValue.TryParseList`, most-specific range wins, q-values honoured) gets the `/api/status` document. A browser's Accept, a bare `*/*`, and an exact tie keep the HTML. Both variants carry `Vary: Accept`; the HTML ETag/304 and 405 logic is untouched and does not leak onto the JSON variant.
- `public/llms.txt` — one-screen Markdown description of the endpoints, the SSE event shapes (`n/at/fr/st/ms/ns`), and the check-in POST.
- `Deucalion.Service --healthcheck` — GETs `http://localhost:{ASPNETCORE_HTTP_PORTS first entry, default 8080}/api/version` with a 3 s timeout, exits 0 on 2xx and 1 otherwise, before any host is built. Plain `HttpClient`, AOT-friendly. Declared in the Dockerfile as `HEALTHCHECK --interval=30s --timeout=5s --start-period=10s`.

**Docs**: README gains an *API* section (all endpoints, negotiation, `llms.txt`, healthcheck); CLAUDE.md notes that the discovery DTOs are deliberately *not* mirrored in `deucalion-types.ts`.

### On #16 — root cause found, and it is not a stale deployment
Running the **native-AOT-published** `Deucalion.Service.exe` locally reproduced the live symptom exactly: `GET /api/monitors/nonexistent-xyz` → `500`, empty body. The log shows why:

```
System.NotSupportedException: JsonTypeInfo metadata for type 'Microsoft.AspNetCore.Mvc.ProblemDetails'
was not provided by TypeInfoResolver of type '[Deucalion.Api.DeucalionJsonContext]'.
```

Under AOT there is no reflection fallback resolver, and `DeucalionJsonContext` never declared `ProblemDetails`, so every `Results.Problem(...)` — the 404, the check-in 400/401, *and the exception handler itself* — threw, which is why the 500 had no body. The JIT test host silently falls back to reflection, so master's tests pass. Fix: one `[JsonSerializable(typeof(ProblemDetails))]` entry, plus a test that pins the declaration (the JIT host cannot reproduce the failure). Verified on the re-published AOT binary (below). The live instance still needs a redeploy from an image containing this fix — that is the operator action outside the repo — and `GET /api/version` now makes it possible to confirm which build is running.

Skipped by design (per `tmp/api-discovery.md`): OpenAPI and `/.well-known/api-catalog`.

## Tests

- `ApiIntegrationTests` (+6): `/api/status` shape, `degraded` / `outage` / `operational` derivation, `since` = start of the trailing run, `latencyMs` omitted on failed probes, links resolve, read-only (monitor `WarnTimeout`/`AutoWarnTimeout` untouched), `/api/version` identity, `ProblemDetails` declared in the JSON context (#16).
- New `Service/DiscoveryHeadTests` (+22 cases): head/noscript injection with HTML-encoding, JSON negotiation (4 accept headers) vs HTML (7 accept headers incl. browser, `*/*`, tie, `q=0`, malformed, absent), JSON ignores the HTML ETag, HEAD+JSON has no body, POST still 405, `/llms.txt` serves the *repo's* file and names every endpoint and SSE key, `--healthcheck` against the real host through `TestServer` (0), non-2xx (1), URL/port selection from `ASPNETCORE_HTTP_PORTS`, connection refused (1), timeout (1).

```
dotnet test -c Release -- --minimum-expected-tests 101
Test run summary: Passed!  total: 195  failed: 0  succeeded: 187  skipped: 8
```

`npm ci && npm run build`: `dist/llms.txt` present; both placeholders survive Vite's HTML pass.

## Example output (AOT-published `Deucalion.Service.exe`, `deucalion-sample.yaml`)

Native AOT `Deucalion.Service.exe` (win-x64), `deucalion-sample.yaml`, `ASPNETCORE_HTTP_PORTS=5099`, `DEUCALION__PAGETITLE="Dataweb status"`:

```
$ curl -si http://localhost:5099/api/version
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
{"name":"Deucalion","version":"1.0.0+3c38c3c4234339f06ce56f3a9839670b2e11c593","runtime":".NET 10.0.9","startedAt":"2026-08-29T05:53:46.537123Z"}

$ curl -s http://localhost:5099/api/status | python -m json.tool
{
    "status": "degraded",
    "updatedAt": "2026-08-29T05:53:54.8415429Z",
    "availability": 80,
    "monitors": [
        { "name": "dns-cf",  "group": "Cloudflare", "type": "dns",  "state": "up",   "since": "2026-08-29T05:53:46.5410825Z", "availability": 100, "latencyMs": 24 },
        { "name": "http-cf", "group": "Cloudflare", "type": "http", "state": "up",   "since": "2026-08-29T05:53:49.8622913Z", "availability": 100, "latencyMs": 103 },
        ...
        { "name": "ping-ms", "group": "Microsoft",  "type": "ping", "state": "down", "since": "2026-08-29T05:53:46.5434838Z", "availability": 0,   "latencyMs": 0 },
        { "name": "chk-test","group": "Others",     "type": "checkin","state": "down","since": "2026-08-29T05:53:46.544019Z",  "availability": 0,   "latencyMs": 0 }
    ],
    "links": { "self": "/api/status", "monitors": "/api/monitors", "events": "/api/monitors/events", "version": "/api/version", "docs": "/llms.txt" }
}

$ curl -si -H 'Accept: application/json' http://localhost:5099/
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Vary: Accept
{"status":"degraded","updatedAt":"2026-08-29T05:53:54.9128491Z","availability":80,"monitors":[...],"links":{...}}

$ curl -s -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' http://localhost:5099/ | grep -E '<title>|alternate|description|noscript'
    <title>Dataweb status</title>
    <link rel="alternate" type="application/json" href="/api/status" />
    <meta name="description" content="Dataweb status — live service status. Machine-readable status at /api/status; docs at /llms.txt" />
    <noscript><p>This page needs JavaScript. Machine-readable status: <a href="/api/status">/api/status</a></p></noscript>

$ curl -sI http://localhost:5099/ | grep -iE 'content-type|vary|etag'      # curl's default Accept: */* keeps HTML
Content-Type: text/html
ETag: "BD070AB4AEFCC32C"
Vary: Accept

$ curl -si http://localhost:5099/llms.txt | head -3
HTTP/1.1 200 OK
Content-Length: 1576
Content-Type: text/plain

$ curl -si http://localhost:5099/api/monitors/nonexistent-xyz               # before the fix: HTTP/1.1 500, Content-Length: 0
HTTP/1.1 404 Not Found
Content-Type: application/problem+json
{"type":"/api/errors/monitor-not-found","title":"Monitor not found.","status":404,"detail":"Monitor 'nonexistent-xyz' not found."}

$ ASPNETCORE_HTTP_PORTS=5099 ./Deucalion.Service.exe --healthcheck; echo exit=$?
exit=0
$ ./Deucalion.Service.exe --healthcheck; echo exit=$?                         # default 8080, nothing listening
exit=1
```

