### PR TITLE
chore: delete dead code and stale artifacts (#30)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,9 +95,6 @@ jobs:
 
       - name: Build frontend
         working-directory: src/ts/deucalion-ui
-        env:
-          VITE_BUILD_VERSION: ${{ needs.version.outputs.semVer }}
-          VITE_INFORMATIONAL_VERSION: ${{ needs.version.outputs.informationalVersion }}
         run: npm run build
 
       - uses: actions/upload-artifact@v7

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ playwright-report/
 # OS cruft
 .DS_Store
 Thumbs.db
+
+# TypeScript incremental build state (written by `tsc --build`)
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ carries the handful of resets the layout actually needs.
 
 ## The wire contract is mirrored by hand
 
-The SSE and REST payloads use short keys (`n`, `at`, `fr`, `st`, `ms`, `ns`) to
+The SSE and REST payloads use short keys (`n`, `at`, `st`, `ms`, `ns`) to
 keep frames small. They are declared twice, with nothing generating one from the
 other:
 

--- a/Deucalion.build.ps1
+++ b/Deucalion.build.ps1
@@ -77,16 +77,8 @@ task Build Version, Clear, {
 
     exec { npm --prefix './src/ts/deucalion-ui' ci }
 
-    # Pass version information to frontend build
-    $env:VITE_BUILD_VERSION = $BuildVersion
-    $env:VITE_INFORMATIONAL_VERSION = $InformationalVersion
-
     # Quote '--' https://stackoverflow.com/a/72260631/332443
     exec { npm --prefix './src/ts/deucalion-ui' run build '--' --outDir "../../../$publishFolder/wwwroot" }
-
-    # Clean up environment variables
-    Remove-Item env:VITE_BUILD_VERSION -ErrorAction SilentlyContinue
-    Remove-Item env:VITE_INFORMATIONAL_VERSION -ErrorAction SilentlyContinue
 }
 
 # synopsis: Start a development environment.

--- a/Deucalion.build.ps1
+++ b/Deucalion.build.ps1
@@ -73,7 +73,7 @@ task Clear-Npm Clear, {
 
 # synopsis: Clear and build projects.
 task Build Version, Clear, {
-    exec { dotnet publish './src/cs/Deucalion.Service/Deucalion.Service.csproj' -c $configuration -o $publishFolder -p:DebugType=None -p:Version=$BuildVersion -p:InformationalVersion=$InformationalVersion --self-contained }
+    exec { dotnet publish './src/cs/Deucalion.Service/Deucalion.Service.csproj' -c $configuration -o $publishFolder -p:DebugType=None -p:Version=$BuildVersion -p:InformationalVersion=$InformationalVersion }
 
     exec { npm --prefix './src/ts/deucalion-ui' ci }
 

--- a/src/cs/Deucalion.Api/Deucalion.Api.csproj
+++ b/src/cs/Deucalion.Api/Deucalion.Api.csproj
@@ -4,6 +4,11 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+
+    <!-- Deucalion.Api is only ever run through `dotnet run`/`dotnet watch` or hosted by
+         Deucalion.Service. The apphost would otherwise be copied into the Service's AOT
+         publish output as a Deucalion.Api.exe that has no Deucalion.Api.dll to load. -->
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/cs/Deucalion.Api/Models/MonitorCheckedDto.cs
+++ b/src/cs/Deucalion.Api/Models/MonitorCheckedDto.cs
@@ -7,7 +7,6 @@ namespace Deucalion.Api.Models;
 public record MonitorCheckedDto(
     [property: JsonPropertyName("n")] string Name,
     [property: JsonPropertyName("at")] long Timestamp,
-    [property: JsonPropertyName("fr")] MonitorState From,
     [property: JsonPropertyName("st")] MonitorState State,
     [property: JsonPropertyName("ms")] int? ResponseTimeMs,
     [property: JsonPropertyName("ns")] MonitorStatsDto NewStats
@@ -17,7 +16,6 @@ public record MonitorCheckedDto(
         new(
             Name: mc.Name,
             Timestamp: mc.At.ToUnixTimeSeconds(),
-            From: mc.From,
             State: mc.Response?.State ?? MonitorState.Unknown,
             ResponseTimeMs: (int?)mc.Response?.ResponseTime?.TotalMilliseconds,
             NewStats: MonitorStatsDto.From(stats, effectiveWarnTimeout, timeout)!

--- a/src/cs/Deucalion.Api/Models/MonitorStateChangedDto.cs
+++ b/src/cs/Deucalion.Api/Models/MonitorStateChangedDto.cs
@@ -6,7 +6,6 @@ namespace Deucalion.Api.Models;
 public record MonitorStateChangedDto(
     [property: JsonPropertyName("n")] string Name,
     [property: JsonPropertyName("at")] long Timestamp,
-    [property: JsonPropertyName("fr")] MonitorState From,
     [property: JsonPropertyName("st")] MonitorState State
 )
 {
@@ -14,7 +13,6 @@ public record MonitorStateChangedDto(
         new(
             Name: msc.Name,
             Timestamp: msc.At.ToUnixTimeSeconds(),
-            From: msc.From,
             State: msc.NewState
         );
 };

--- a/src/cs/Deucalion.Service/Deucalion.Service.csproj
+++ b/src/cs/Deucalion.Service/Deucalion.Service.csproj
@@ -7,9 +7,6 @@
 
     <!-- "web.config" file is unnecessary for a Windows Services app. Source: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/windows-service?view=aspnetcore-7.0&tabs=visual-studio#framework-dependent-deployment-fdd -->
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
-    
-    <!-- Ignore errors about duplicate "appsettings.json" files in publish folder. Source: https://stackoverflow.com/a/69919694-->      
-    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
 
     <PublishAot>true</PublishAot>
     <ValidateExecutableReferencesMatchSelfContained>false</ValidateExecutableReferencesMatchSelfContained>

--- a/src/ts/deucalion-ui/playwright.config.ts
+++ b/src/ts/deucalion-ui/playwright.config.ts
@@ -13,6 +13,7 @@ const BASE_URL = `http://localhost:${PORT.toString()}`;
 // process (`reuseExistingServer: !CI`).
 export default defineConfig({
   testDir: "./tests/e2e",
+  globalTeardown: "./tests/e2e/global-teardown.ts",
   fullyParallel: false,
   // One retry hedges against a runner hiccup. More than that mostly hides
   // real regressions, and every assertion already carries a generous timeout.

--- a/src/ts/deucalion-ui/src/app.tsx
+++ b/src/ts/deucalion-ui/src/app.tsx
@@ -4,7 +4,7 @@ import { configuration } from "./stores/configuration-store";
 import { monitorsLoaded } from "./stores/monitors-store";
 
 import { TopBar } from "./components/top-bar";
-import { Hero } from "./components/hero/hero";
+import { HeroAvailability } from "./components/hero/hero-availability";
 import { MonitorList } from "./components/monitor/monitor-list";
 import { Footer } from "./components/footer";
 import { ToastStack } from "./components/common/toast";
@@ -45,7 +45,9 @@ export const App: Component = () => {
       <Show when={ready()}>
         <div class="shell">
           <TopBar />
-          <Hero />
+          <div class="hero">
+            <HeroAvailability />
+          </div>
           <MonitorList />
           <Footer />
         </div>

--- a/src/ts/deucalion-ui/src/components/common/icons.tsx
+++ b/src/ts/deucalion-ui/src/components/common/icons.tsx
@@ -17,37 +17,9 @@ export const MoonIcon: Component<IconProps> = (props) => (
   </svg>
 );
 
-export const SlidersIcon: Component<IconProps> = (props) => (
-  <svg width={props.size ?? 14} height={props.size ?? 14} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <line x1="4" y1="21" x2="4" y2="14" />
-    <line x1="4" y1="10" x2="4" y2="3" />
-    <line x1="12" y1="21" x2="12" y2="12" />
-    <line x1="12" y1="8" x2="12" y2="3" />
-    <line x1="20" y1="21" x2="20" y2="16" />
-    <line x1="20" y1="12" x2="20" y2="3" />
-    <line x1="1" y1="14" x2="7" y2="14" />
-    <line x1="9" y1="8" x2="15" y2="8" />
-    <line x1="17" y1="16" x2="23" y2="16" />
-  </svg>
-);
-
 export const XIcon: Component<IconProps> = (props) => (
   <svg width={props.size ?? 14} height={props.size ?? 14} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <line x1="18" y1="6" x2="6" y2="18" />
     <line x1="6" y1="6" x2="18" y2="18" />
-  </svg>
-);
-
-export const ArrowUpIcon: Component<IconProps> = (props) => (
-  <svg width={props.size ?? 10} height={props.size ?? 10} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <line x1="12" y1="19" x2="12" y2="5" />
-    <polyline points="5 12 12 5 19 12" />
-  </svg>
-);
-
-export const ArrowDownIcon: Component<IconProps> = (props) => (
-  <svg width={props.size ?? 10} height={props.size ?? 10} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-    <line x1="12" y1="5" x2="12" y2="19" />
-    <polyline points="19 12 12 19 5 12" />
   </svg>
 );

--- a/src/ts/deucalion-ui/src/components/hero/hero.tsx
+++ b/src/ts/deucalion-ui/src/components/hero/hero.tsx
@@ -1,9 +1,0 @@
-import type { Component } from "solid-js";
-
-import { HeroAvailability } from "./hero-availability";
-
-export const Hero: Component = () => (
-  <div class="hero">
-    <HeroAvailability />
-  </div>
-);

--- a/src/ts/deucalion-ui/src/components/monitor/lat-stats.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/lat-stats.tsx
@@ -1,18 +1,18 @@
 import type { Component } from "solid-js";
 
-import type { MonitorProps } from "../../services/deucalion-types";
+import type { MonitorDto } from "../../services/deucalion-types";
 import { fmtMs } from "../../services/formatting";
 import { minMs, percentile } from "../../services/monitor-stats";
 import { SPARKLINE_NOISE_FLOOR_MS } from "./sparkline";
 
 interface LatStatsProps {
-  monitor: MonitorProps;
+  monitor: MonitorDto;
 }
 
 export const LatStats: Component<LatStatsProps> = (props) => {
   // Prefer backend-computed percentiles when present; fall back to a
   // client-side computation over the event window.
-  const stats = (): MonitorProps["stats"] => props.monitor.stats;
+  const stats = (): MonitorDto["stats"] => props.monitor.stats;
   const min = (): number | undefined => stats()?.minResponseTimeMs ?? minMs(props.monitor.events);
   const p50 = (): number | undefined => stats()?.latency50Ms ?? percentile(props.monitor.events, 0.5);
   const p95 = (): number | undefined => stats()?.latency95Ms ?? percentile(props.monitor.events, 0.95);

--- a/src/ts/deucalion-ui/src/components/monitor/monitor-list.test.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/monitor-list.test.tsx
@@ -31,11 +31,4 @@ describe("<MonitorList>", () => {
     expect(subs).toContain("Edge");
     expect(subs).toContain("Origin");
   });
-
-  it("does not render a group-header any more (count + tally moved to the hero)", () => {
-    __seedMonitorsForTests([buildMonitor({ name: "a" }), buildMonitor({ name: "b" })]);
-    const { container } = render(() => <MonitorList />);
-    expect(container.querySelector(".group-header")).toBeNull();
-    expect(container.querySelector(".group-title")).toBeNull();
-  });
 });

--- a/src/ts/deucalion-ui/src/components/monitor/monitor-list.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/monitor-list.tsx
@@ -1,19 +1,19 @@
 import { For, type Component, createMemo, Show } from "solid-js";
 
 import { monitorList } from "../../stores/monitors-store";
-import type { MonitorProps } from "../../services/deucalion-types";
+import type { MonitorDto } from "../../services/deucalion-types";
 
 import { MonitorRow } from "./monitor-row";
 
 interface SubGroup {
   name: string;
-  monitors: MonitorProps[];
+  monitors: MonitorDto[];
 }
 
 const NO_GROUP_LABEL = "Monitors";
 
-const buildSubgroups = (monitors: MonitorProps[]): SubGroup[] => {
-  const map = new Map<string, MonitorProps[]>();
+const buildSubgroups = (monitors: MonitorDto[]): SubGroup[] => {
+  const map = new Map<string, MonitorDto[]>();
   for (const m of monitors) {
     const key = m.config.group ?? NO_GROUP_LABEL;
     const list = map.get(key);

--- a/src/ts/deucalion-ui/src/components/monitor/monitor-row.tsx
+++ b/src/ts/deucalion-ui/src/components/monitor/monitor-row.tsx
@@ -1,6 +1,6 @@
 import { type Component, createEffect, createMemo, createSignal, onCleanup, Show } from "solid-js";
 
-import { MonitorState, type MonitorProps } from "../../services/deucalion-types";
+import { MonitorState, type MonitorDto } from "../../services/deucalion-types";
 import { avail, lastIncident } from "../../services/monitor-stats";
 import { fmtAgo, stateName } from "../../services/formatting";
 
@@ -9,7 +9,7 @@ import { LatStats } from "./lat-stats";
 import { Sparkline } from "./sparkline";
 
 interface MonitorRowProps {
-  monitor: MonitorProps;
+  monitor: MonitorDto;
 }
 
 export const MonitorRow: Component<MonitorRowProps> = (props) => {

--- a/src/ts/deucalion-ui/src/components/top-bar.test.tsx
+++ b/src/ts/deucalion-ui/src/components/top-bar.test.tsx
@@ -35,13 +35,6 @@ describe("<TopBar>", () => {
     expect(tweaks.theme()).toBe("dark");
   });
 
-  it("does not render a visible tweaks trigger (panel is now console-only)", () => {
-    __seedMonitorsForTests([]);
-    render(() => <TopBar />);
-    const trigger = document.querySelector('button[aria-label="Open tweaks panel"]');
-    expect(trigger).toBeNull();
-  });
-
   it("updates document.title with a (-N) prefix when monitors are down", () => {
     __seedMonitorsForTests([
       buildMonitor({ name: "a", stats: buildStats({ lastState: MonitorState.Down }) }),

--- a/src/ts/deucalion-ui/src/components/tweaks/tweaks-controls.test.tsx
+++ b/src/ts/deucalion-ui/src/components/tweaks/tweaks-controls.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render } from "@solidjs/testing-library";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { TweakRadio, TweakSelect, TweakSlider } from "./tweaks-controls";
+import { TweakSelect, TweakSlider } from "./tweaks-controls";
 
 const OPTIONS = [
   { value: "a", label: "A" },
@@ -9,16 +9,6 @@ const OPTIONS = [
   { value: "c", label: "C" },
   { value: "d", label: "D" },
 ];
-
-// jsdom has no layout, so getBoundingClientRect returns all zeros. Stub a
-// 404px-wide track: with the 2px inset on each side the usable width is 400px,
-// giving four 100px segments starting at x=2.
-const stubTrack = (container: HTMLElement): void => {
-  const track = container.querySelector<HTMLElement>(".twk-seg");
-  if (!track) throw new Error("track not rendered");
-  track.getBoundingClientRect = (): DOMRect =>
-    ({ left: 0, top: 0, width: 404, height: 24, right: 404, bottom: 24, x: 0, y: 0, toJSON: () => ({}) });
-};
 
 describe("<TweakSlider />", () => {
   afterEach(cleanup);
@@ -60,113 +50,6 @@ describe("<TweakSlider />", () => {
     fireEvent.input(input, { target: { value: "21" } });
 
     expect(onChange).toHaveBeenCalledWith(21);
-  });
-});
-
-describe("<TweakRadio />", () => {
-  afterEach(cleanup);
-
-  // jsdom re-serialises calc(): `2 * (100% - 4px) / 4` comes back as
-  // `0.5 * (100% - 4px)`. Recover the segment index from that fraction rather
-  // than asserting on the exact string.
-  const thumbIndex = (container: HTMLElement, segments = OPTIONS.length): number => {
-    const left = container.querySelector<HTMLElement>(".twk-seg-thumb")?.style.left ?? "";
-    const match = /2px \+ ([\d.]+) \*/.exec(left);
-    if (!match) throw new Error(`Unexpected thumb offset: ${left}`);
-    return Math.round(Number(match[1]) * segments);
-  };
-
-  it("positions the thumb over the selected segment", () => {
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="c" options={OPTIONS} onChange={() => { /* noop */ }} />
-    ));
-
-    expect(thumbIndex(container)).toBe(2);
-    // Width is one segment: the track minus the 2px inset each side, over N.
-    // jsdom folds the "/ 4" into a 0.25 multiplier.
-    expect(container.querySelector<HTMLElement>(".twk-seg-thumb")?.style.width)
-      .toMatch(/(0\.25 \*|\/ 4)/);
-  });
-
-  it("falls back to the first segment when the value is unknown", () => {
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="nope" options={OPTIONS} onChange={() => { /* noop */ }} />
-    ));
-
-    expect(thumbIndex(container)).toBe(0);
-  });
-
-  it("tracks the selected index across every option", () => {
-    for (const [i, option] of OPTIONS.entries()) {
-      const { container, unmount } = render(() => (
-        <TweakRadio label="Pick" value={option.value} options={OPTIONS} onChange={() => { /* noop */ }} />
-      ));
-      expect(thumbIndex(container)).toBe(i);
-      unmount();
-    }
-  });
-
-  it("marks only the selected option as checked", () => {
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="b" options={OPTIONS} onChange={() => { /* noop */ }} />
-    ));
-
-    const checked = [...container.querySelectorAll("[role=radio]")]
-      .map((el) => el.getAttribute("aria-checked"));
-    expect(checked).toEqual(["false", "true", "false", "false"]);
-  });
-
-  it.each([
-    { clientX: 2, expected: "a" },
-    { clientX: 101, expected: "a" },
-    { clientX: 102, expected: "b" },
-    { clientX: 250, expected: "c" },
-    { clientX: 380, expected: "d" },
-  ])("maps x=$clientX to segment $expected", ({ clientX, expected }) => {
-    const onChange = vi.fn();
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="a" options={OPTIONS} onChange={onChange} />
-    ));
-    stubTrack(container);
-
-    fireEvent.pointerDown(container.querySelector(".twk-seg")!, { clientX });
-
-    if (expected === "a") {
-      // Already selected -- the component must not fire a redundant change.
-      expect(onChange).not.toHaveBeenCalled();
-    } else {
-      expect(onChange).toHaveBeenCalledWith(expected);
-    }
-  });
-
-  it("clamps a pointer past either end to the first and last segments", () => {
-    const onChange = vi.fn();
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="b" options={OPTIONS} onChange={onChange} />
-    ));
-    stubTrack(container);
-    const track = container.querySelector(".twk-seg")!;
-
-    fireEvent.pointerDown(track, { clientX: -500 });
-    expect(onChange).toHaveBeenLastCalledWith("a");
-
-    fireEvent.pointerDown(track, { clientX: 9999 });
-    expect(onChange).toHaveBeenLastCalledWith("d");
-  });
-
-  it("marks the track as dragging while the pointer is down", () => {
-    const { container } = render(() => (
-      <TweakRadio label="Pick" value="a" options={OPTIONS} onChange={() => { /* noop */ }} />
-    ));
-    stubTrack(container);
-    const track = container.querySelector(".twk-seg")!;
-
-    expect(track.className).toBe("twk-seg");
-    fireEvent.pointerDown(track, { clientX: 250 });
-    expect(track.className).toBe("twk-seg dragging");
-
-    fireEvent.pointerUp(window);
-    expect(track.className).toBe("twk-seg");
   });
 });
 

--- a/src/ts/deucalion-ui/src/components/tweaks/tweaks-controls.tsx
+++ b/src/ts/deucalion-ui/src/components/tweaks/tweaks-controls.tsx
@@ -1,4 +1,4 @@
-import { For, type Component, type JSX, createSignal } from "solid-js";
+import { For, type Component, type JSX } from "solid-js";
 
 interface TweakSectionProps {
   label: string;
@@ -54,75 +54,6 @@ export const TweakSlider: Component<TweakSliderProps> = (props) => (
 );
 
 interface RadioOption { value: string; label: string }
-
-interface TweakRadioProps {
-  label: string;
-  value: string;
-  options: RadioOption[];
-  onChange: (v: string) => void;
-}
-
-export const TweakRadio: Component<TweakRadioProps> = (props) => {
-  let trackRef!: HTMLDivElement;
-  const [dragging, setDragging] = createSignal(false);
-  const idx = (): number => {
-    const i = props.options.findIndex((o) => o.value === props.value);
-    return i < 0 ? 0 : i;
-  };
-  const n = (): number => props.options.length;
-
-  const segAt = (clientX: number): string => {
-    const r = trackRef.getBoundingClientRect();
-    const inner = r.width - 4;
-    let i = Math.floor(((clientX - r.left - 2) / inner) * n());
-    if (i < 0) i = 0;
-    if (i >= n()) i = n() - 1;
-    return props.options[i].value;
-  };
-
-  const onPointerDown = (e: PointerEvent): void => {
-    setDragging(true);
-    const v0 = segAt(e.clientX);
-    if (v0 !== props.value) props.onChange(v0);
-    const move = (ev: PointerEvent): void => {
-      const v = segAt(ev.clientX);
-      if (v !== props.value) props.onChange(v);
-    };
-    const up = (): void => {
-      setDragging(false);
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
-  };
-
-  return (
-    <TweakRow label={props.label}>
-      <div
-        ref={trackRef}
-        role="radiogroup"
-        onPointerDown={onPointerDown}
-        class={dragging() ? "twk-seg dragging" : "twk-seg"}
-      >
-        <div
-          class="twk-seg-thumb"
-          style={{
-            left: `calc(2px + ${idx().toString()} * (100% - 4px) / ${n().toString()})`,
-            width: `calc((100% - 4px) / ${n().toString()})`,
-          }}
-        />
-        <For each={props.options}>
-          {(o) => (
-            <button type="button" role="radio" aria-checked={o.value === props.value}>
-              {o.label}
-            </button>
-          )}
-        </For>
-      </div>
-    </TweakRow>
-  );
-};
 
 interface TweakSelectProps {
   label: string;

--- a/src/ts/deucalion-ui/src/services/deucalion-types.ts
+++ b/src/ts/deucalion-ui/src/services/deucalion-types.ts
@@ -37,7 +37,6 @@ export interface MonitorEventDto {
 export interface MonitorCheckedDto {
   n: string;
   at: number;
-  fr: MonitorState;
   st: MonitorState;
   ms?: number;
   ns: MonitorStatsDto;
@@ -46,7 +45,6 @@ export interface MonitorCheckedDto {
 export interface MonitorStateChangedDto {
   n: string;
   at: number;
-  fr: MonitorState;
   st: MonitorState;
 }
 

--- a/src/ts/deucalion-ui/src/services/deucalion-types.ts
+++ b/src/ts/deucalion-ui/src/services/deucalion-types.ts
@@ -48,7 +48,7 @@ export interface MonitorStateChangedDto {
   st: MonitorState;
 }
 
-export interface MonitorProps {
+export interface MonitorDto {
   name: string;
   config: MonitorConfigurationDto;
   stats?: MonitorStatsDto;

--- a/src/ts/deucalion-ui/src/services/fetch-with-retry.test.ts
+++ b/src/ts/deucalion-ui/src/services/fetch-with-retry.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  __resetBackendPhaseForTests,
-  backendPhase,
-  fetchWithRetry,
-} from "./fetch-with-retry";
+import { fetchWithRetry } from "./fetch-with-retry";
 
 const okResponse = (body: unknown = {}): Response =>
   new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
@@ -14,12 +10,11 @@ const transientResponse = (status: number): Response =>
 
 describe("fetchWithRetry", () => {
   beforeEach(() => {
-    __resetBackendPhaseForTests();
     vi.useFakeTimers();
   });
   afterEach(() => { vi.useRealTimers(); });
 
-  it("returns the response and flips the phase to ready on first success", async () => {
+  it("returns the response on first success", async () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce(okResponse({ ok: true }));
     vi.stubGlobal("fetch", fetchSpy);
 
@@ -27,10 +22,9 @@ describe("fetchWithRetry", () => {
 
     expect(res.ok).toBe(true);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(backendPhase()).toBe("ready");
   });
 
-  it("retries 502s and surfaces 'waiting' until a 200 lands", async () => {
+  it("retries 502s until a 200 lands", async () => {
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce(transientResponse(502))
       .mockResolvedValueOnce(transientResponse(503))
@@ -44,7 +38,6 @@ describe("fetchWithRetry", () => {
 
     expect(res.ok).toBe(true);
     expect(fetchSpy).toHaveBeenCalledTimes(3);
-    expect(backendPhase()).toBe("ready");
   });
 
   it("retries network errors", async () => {
@@ -67,26 +60,5 @@ describe("fetchWithRetry", () => {
 
     await expect(fetchWithRetry("/api/missing")).rejects.toThrow(/HTTP 404/);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it("flips phase to 'waiting' while a transient retry loop is in flight", async () => {
-    // Hold the second fetch indefinitely so the loop pauses with phase="waiting"
-    // long enough for the assertion to land.
-    let releaseSecond: (r: Response) => void = () => undefined;
-    const fetchSpy = vi.fn()
-      .mockResolvedValueOnce(transientResponse(502))
-      .mockImplementationOnce(() => new Promise<Response>((resolve) => { releaseSecond = resolve; }));
-    vi.stubGlobal("fetch", fetchSpy);
-
-    const promise = fetchWithRetry("/api/configuration");
-    // Drain the failed first attempt + the backoff sleep so the helper is now
-    // sat on the second `await fetch(...)`.
-    await vi.runAllTimersAsync();
-    await Promise.resolve();
-    expect(backendPhase()).toBe("waiting");
-
-    releaseSecond(okResponse());
-    await promise;
-    expect(backendPhase()).toBe("ready");
   });
 });

--- a/src/ts/deucalion-ui/src/services/fetch-with-retry.ts
+++ b/src/ts/deucalion-ui/src/services/fetch-with-retry.ts
@@ -1,15 +1,4 @@
-import { createSignal } from "solid-js";
-
 import * as logger from "./logger";
-
-// Connection phase, used by the loading screen and the SSE indicator.
-//   "initial"  — first request in flight, no failure yet
-//   "waiting"  — at least one transient failure; backend likely still booting
-//   "ready"    — initial fetch succeeded
-export type BackendPhase = "initial" | "waiting" | "ready";
-
-const [phase, setPhase] = createSignal<BackendPhase>("initial");
-export const backendPhase = phase;
 
 const sleep = (ms: number): Promise<void> =>
   new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -17,7 +6,7 @@ const sleep = (ms: number): Promise<void> =>
 // 250 ms, 500 ms, 1 s, 2 s, then capped at 5 s.
 const backoff = (attempt: number): number => Math.min(5000, 250 * 2 ** Math.max(0, attempt - 1));
 
-const isTransient = (status: number): boolean => status === 0 || status >= 500;
+const isTransient = (status: number): boolean => status >= 500;
 
 export interface FetchOptions {
   signal?: AbortSignal;
@@ -37,24 +26,16 @@ export const fetchWithRetry = async (url: string, opts: FetchOptions = {}): Prom
       // AbortError propagates immediately — nothing to retry against.
       if (e instanceof DOMException && e.name === "AbortError") throw e;
       logger.warn(`[fetchWithRetry] ${url} threw; retrying (attempt ${attempt.toString()})`, e);
-      setPhase("waiting");
       await sleep(backoff(attempt));
       continue;
     }
-    if (res.ok) {
-      setPhase("ready");
-      return res;
-    }
+    if (res.ok) return res;
     if (!isTransient(res.status)) {
       // 4xx responses surface as a permanent error — the resource consumer
       // (Solid's createResource) will route them to <ErrorBoundary>.
       throw new Error(`HTTP ${res.status.toString()} ${res.statusText} for ${url}`);
     }
     logger.warn(`[fetchWithRetry] ${url} returned ${res.status.toString()}; retrying (attempt ${attempt.toString()})`);
-    setPhase("waiting");
     await sleep(backoff(attempt));
   }
 };
-
-// Test-only reset of the phase signal.
-export const __resetBackendPhaseForTests = (): void => { setPhase("initial"); };

--- a/src/ts/deucalion-ui/src/services/formatting.test.ts
+++ b/src/ts/deucalion-ui/src/services/formatting.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MonitorState } from "./deucalion-types";
 import {
   fmtAgo,
-  fmtDur,
   fmtMs,
   monitorStateToDescription,
   monitorStateToToastVariant,
@@ -28,7 +27,7 @@ describe("fmtMs", () => {
   });
 });
 
-describe("fmtAgo / fmtDur", () => {
+describe("fmtAgo", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
@@ -43,14 +42,6 @@ describe("fmtAgo / fmtDur", () => {
     expect(fmtAgo(nowSec() - 90)).toBe("2m ago");
     expect(fmtAgo(nowSec() - 7200)).toBe("2h ago");
     expect(fmtAgo(nowSec() - 86400 * 3)).toBe("3d ago");
-  });
-
-  it("formats durations with the same buckets", () => {
-    expect(fmtDur(0)).toBe("0s");
-    expect(fmtDur(45)).toBe("45s");
-    expect(fmtDur(120)).toBe("2m");
-    expect(fmtDur(7200)).toBe("2.0h");
-    expect(fmtDur(86400 * 3)).toBe("3.0d");
   });
 });
 

--- a/src/ts/deucalion-ui/src/services/formatting.ts
+++ b/src/ts/deucalion-ui/src/services/formatting.ts
@@ -15,13 +15,6 @@ export const fmtAgo = (epochSeconds: number): string => {
   return `${Math.round(diff / 86400).toString()}d ago`;
 };
 
-export const fmtDur = (seconds: number): string => {
-  if (seconds < 60) return `${Math.round(seconds).toString()}s`;
-  if (seconds < 3600) return `${Math.round(seconds / 60).toString()}m`;
-  if (seconds < 86400) return `${(seconds / 3600).toFixed(1)}h`;
-  return `${(seconds / 86400).toFixed(1)}d`;
-};
-
 export const fmtTime = (epochSeconds: number): string => {
   const d = new Date(epochSeconds * 1000);
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });

--- a/src/ts/deucalion-ui/src/services/monitor-stats.test.ts
+++ b/src/ts/deucalion-ui/src/services/monitor-stats.test.ts
@@ -5,7 +5,6 @@ import { MonitorState } from "./deucalion-types";
 import {
   aggregateAvailability,
   avail,
-  avgMs,
   lastIncident,
   minMs,
   percentile,
@@ -51,20 +50,18 @@ describe("avail()", () => {
   });
 });
 
-describe("avgMs() / minMs()", () => {
+describe("minMs()", () => {
   it("returns undefined when no event has a response time", () => {
     const events = buildEvents([MonitorState.Down, MonitorState.Down], {
       ms: () => undefined,
     });
-    expect(avgMs(events)).toBeUndefined();
     expect(minMs(events)).toBeUndefined();
   });
 
-  it("averages only the events that carry an ms value", () => {
+  it("considers only the events that carry an ms value", () => {
     const events = buildEvents([MonitorState.Up, MonitorState.Down, MonitorState.Up], {
       ms: (_i, st) => (st === MonitorState.Down ? undefined : 100),
     });
-    expect(avgMs(events)).toBe(100);
     expect(minMs(events)).toBe(100);
   });
 
@@ -73,7 +70,6 @@ describe("avgMs() / minMs()", () => {
       ms: (i) => [120, 30, 80][i],
     });
     expect(minMs(events)).toBe(30);
-    expect(avgMs(events)).toBeCloseTo((120 + 30 + 80) / 3);
   });
 
   it("excludes Down events that carry a timing (e.g. PingMonitor 0ms failures)", () => {
@@ -84,7 +80,6 @@ describe("avgMs() / minMs()", () => {
       [MonitorState.Down, MonitorState.Down, MonitorState.Up, MonitorState.Down],
       { ms: (_i, st) => (st === MonitorState.Down ? 0 : 50) },
     );
-    expect(avgMs(events)).toBe(50);
     expect(minMs(events)).toBe(50);
   });
 });

--- a/src/ts/deucalion-ui/src/services/monitor-stats.ts
+++ b/src/ts/deucalion-ui/src/services/monitor-stats.ts
@@ -1,4 +1,4 @@
-import { MonitorState, type MonitorEventDto, type MonitorProps } from "./deucalion-types";
+import { MonitorState, type MonitorEventDto, type MonitorDto } from "./deucalion-types";
 
 // Pure helpers over MonitorEventDto[]. The backend returns events newest-first,
 // and we keep that convention internally.
@@ -90,7 +90,7 @@ export interface AggregateAvailability {
 
 // Aggregate availability across all monitors. We use stats.availability when
 // present and fall back to computing from events.
-export const aggregateAvailability = (monitors: MonitorProps[]): AggregateAvailability => {
+export const aggregateAvailability = (monitors: MonitorDto[]): AggregateAvailability => {
   let sum = 0;
   let up = 0, warn = 0, down = 0, degraded = 0, unknown = 0;
   for (const m of monitors) {

--- a/src/ts/deucalion-ui/src/services/monitor-stats.ts
+++ b/src/ts/deucalion-ui/src/services/monitor-stats.ts
@@ -23,18 +23,6 @@ export const avail = (events: MonitorEventDto[]): number => {
   return ((total - down) / total) * 100;
 };
 
-export const avgMs = (events: MonitorEventDto[]): number | undefined => {
-  let sum = 0;
-  let n = 0;
-  for (const e of events) {
-    if (e.ms != null && isHealthyLatency(e.st)) {
-      sum += e.ms;
-      n++;
-    }
-  }
-  return n > 0 ? sum / n : undefined;
-};
-
 export const minMs = (events: MonitorEventDto[]): number | undefined => {
   let min: number | undefined;
   for (const e of events) {

--- a/src/ts/deucalion-ui/src/stores/monitors-store.test.ts
+++ b/src/ts/deucalion-ui/src/stores/monitors-store.test.ts
@@ -33,7 +33,6 @@ describe("monitors-store", () => {
     const checked = (over: Partial<MonitorCheckedDto> = {}): MonitorCheckedDto => ({
       n: "m1",
       at: 1_700_000_001,
-      fr: MonitorState.Up,
       st: MonitorState.Warn,
       ms: 100,
       ns: buildStats({ lastState: MonitorState.Warn }),

--- a/src/ts/deucalion-ui/src/stores/monitors-store.ts
+++ b/src/ts/deucalion-ui/src/stores/monitors-store.ts
@@ -5,12 +5,12 @@ import { API_MONITORS_URL, MAX_EVENT_HISTORY } from "../configuration";
 import type {
   MonitorCheckedDto,
   MonitorEventDto,
-  MonitorProps,
+  MonitorDto,
 } from "../services/deucalion-types";
 import { fetchWithRetry } from "../services/fetch-with-retry";
 
 interface MonitorsStoreState {
-  byName: Record<string, MonitorProps>;
+  byName: Record<string, MonitorDto>;
   order: string[];
   loaded: boolean;
 }
@@ -21,9 +21,9 @@ const [state, setState] = createStore<MonitorsStoreState>({
   loaded: false,
 });
 
-const fetchMonitors = async (): Promise<MonitorProps[]> => {
+const fetchMonitors = async (): Promise<MonitorDto[]> => {
   const response = await fetchWithRetry(API_MONITORS_URL);
-  return await response.json() as MonitorProps[];
+  return await response.json() as MonitorDto[];
 };
 
 const [monitorsResource] = createResource(async () => {
@@ -47,10 +47,10 @@ export const monitors = state;
 export { monitorsResource };
 export const monitorsLoaded = (): boolean => state.loaded;
 
-export const monitorList = (): MonitorProps[] => state.order.map((name) => state.byName[name]);
+export const monitorList = (): MonitorDto[] => state.order.map((name) => state.byName[name]);
 
 // Test-only: replace the in-memory monitor list with a fixed set.
-export const __seedMonitorsForTests = (list: MonitorProps[]): void => {
+export const __seedMonitorsForTests = (list: MonitorDto[]): void => {
   setState(
     produce((s) => {
       s.byName = {};

--- a/src/ts/deucalion-ui/src/stores/sse.test.ts
+++ b/src/ts/deucalion-ui/src/stores/sse.test.ts
@@ -91,7 +91,6 @@ describe("connectSSE()", () => {
     lastSource().emit("MonitorChecked", {
       n: "m1",
       at: 100,
-      fr: MonitorState.Up,
       st: MonitorState.Down,
       ms: 250,
       ns: { lastState: MonitorState.Down, availability: 0 },
@@ -107,7 +106,6 @@ describe("connectSSE()", () => {
     lastSource().emit("MonitorStateChanged", {
       n: "m1",
       at: 100,
-      fr: MonitorState.Up,
       st: MonitorState.Down,
     });
 

--- a/src/ts/deucalion-ui/src/stores/toast-store.test.ts
+++ b/src/ts/deucalion-ui/src/stores/toast-store.test.ts
@@ -37,7 +37,6 @@ describe("toast-store", () => {
     const event: MonitorStateChangedDto = {
       n: "api-prod",
       at: 0,
-      fr: MonitorState.Up,
       st: MonitorState.Down,
     };
 

--- a/src/ts/deucalion-ui/src/styles/layout.css
+++ b/src/ts/deucalion-ui/src/styles/layout.css
@@ -161,14 +161,6 @@
   row-gap: 6px;
 }
 
-.hero-label {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--fg-3);
-  font-weight: 500;
-}
-
 .hero-availability {
   font-family: var(--font-display);
   font-size: 64px;
@@ -232,12 +224,6 @@
 .hero-chip.up strong { color: var(--up); }
 .hero-chip.warn strong { color: var(--warn); }
 .hero-chip.down strong { color: var(--down); }
-.hero-chip-total {
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-size: 11px;
-}
-
 .hero-spark-wrap {
   grid-area: spark;
   width: 240px;
@@ -278,43 +264,6 @@
 .group {
   margin-top: 36px;
 }
-
-.group-header {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  padding-bottom: 12px;
-  margin-bottom: 8px;
-  border-bottom: 1px solid var(--line);
-}
-
-.group-title {
-  font-family: var(--font-display);
-  font-size: 28px;
-  font-weight: 500;
-  letter-spacing: -0.025em;
-  color: var(--fg);
-  margin: 0;
-}
-.group-title em {
-  font-style: var(--display-italic);
-  color: var(--fg-3);
-  font-weight: 400;
-}
-
-.group-meta {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--fg-3);
-  display: flex;
-  gap: 14px;
-  margin-left: auto;
-  letter-spacing: 0.02em;
-}
-
-.group-meta-up { color: var(--up); }
-.group-meta-warn { color: var(--warn); }
-.group-meta-down { color: var(--down); }
 
 /* ============= MONITOR ROW ============= */
 .row {

--- a/src/ts/deucalion-ui/src/styles/tweaks.css
+++ b/src/ts/deucalion-ui/src/styles/tweaks.css
@@ -173,41 +173,6 @@ select.twk-field {
   cursor: pointer;
 }
 
-.twk-seg {
-  position: relative;
-  display: flex;
-  padding: 2px;
-  border-radius: 8px;
-  background: rgba(0, 0, 0, 0.06);
-  user-select: none;
-}
-[data-theme="dark"] .twk-seg { background: rgba(255, 255, 255, 0.08); }
-.twk-seg-thumb {
-  position: absolute;
-  top: 2px; bottom: 2px;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
-  transition: left 0.15s cubic-bezier(0.3, 0.7, 0.4, 1), width 0.15s;
-}
-[data-theme="dark"] .twk-seg-thumb { background: rgba(255, 255, 255, 0.18); }
-.twk-seg.dragging .twk-seg-thumb { transition: none; }
-.twk-seg button {
-  appearance: none;
-  position: relative;
-  z-index: 1;
-  flex: 1;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  font-weight: 500;
-  height: 22px;
-  border-radius: 6px;
-  cursor: pointer;
-  padding: 0;
-}
-
 .twk-btn {
   appearance: none;
   height: 26px;

--- a/src/ts/deucalion-ui/src/test/fixtures.ts
+++ b/src/ts/deucalion-ui/src/test/fixtures.ts
@@ -1,7 +1,7 @@
 import {
   MonitorState,
   type MonitorEventDto,
-  type MonitorProps,
+  type MonitorDto,
   type MonitorStatsDto,
 } from "../services/deucalion-types";
 
@@ -43,7 +43,7 @@ export const buildStats = (over: Partial<MonitorStatsDto> = {}): MonitorStatsDto
   ...over,
 });
 
-export const buildMonitor = (over: Partial<MonitorProps> = {}): MonitorProps => ({
+export const buildMonitor = (over: Partial<MonitorDto> = {}): MonitorDto => ({
   name: "test-monitor",
   config: { type: "http" },
   stats: buildStats(),

--- a/src/ts/deucalion-ui/tests/e2e/dashboard.spec.ts
+++ b/src/ts/deucalion-ui/tests/e2e/dashboard.spec.ts
@@ -43,7 +43,7 @@ test.describe("Deucalion dashboard", () => {
 });
 
 test.describe("Wire contract", () => {
-  // Nothing else catches a rename of the short SSE keys (n/at/fr/st/ms/ns),
+  // Nothing else catches a rename of the short SSE keys (n/at/st/ms/ns),
   // which are mirrored by hand between Deucalion.Api/Models/*.cs and
   // src/services/deucalion-types.ts. The heartbeat ticks rendered on load come
   // from GET /api/monitors, so only a *live* update exercises mergeChecked.

--- a/src/ts/deucalion-ui/tests/e2e/dashboard.spec.ts
+++ b/src/ts/deucalion-ui/tests/e2e/dashboard.spec.ts
@@ -40,12 +40,6 @@ test.describe("Deucalion dashboard", () => {
     expect(badgeClasses).not.toContain(null);
     expect(new Set(badgeClasses).size).toBeGreaterThan(1);
   });
-
-  test("event feed is no longer rendered (data still flows via SSE)", async ({ page }) => {
-    await page.goto("/");
-    await waitForDashboard(page);
-    await expect(page.locator(".feed")).toHaveCount(0);
-  });
 });
 
 test.describe("Wire contract", () => {

--- a/src/ts/deucalion-ui/tests/e2e/global-teardown.ts
+++ b/src/ts/deucalion-ui/tests/e2e/global-teardown.ts
@@ -1,0 +1,11 @@
+import { rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+// playwright.config.ts points the backend at ./.e2e-storage, which `dotnet run`
+// resolves against the project directory. The SQLite database (and its WAL)
+// would otherwise accumulate across runs; nothing else cleans it up.
+const storageDir = fileURLToPath(new URL("../../../../cs/Deucalion.Api/.e2e-storage", import.meta.url));
+
+export default async (): Promise<void> => {
+  await rm(storageDir, { recursive: true, force: true });
+};


### PR DESCRIPTION
Closes #30

Every item in the issue was re-verified against current `master` before acting; several had already been handled by earlier PRs.

## Deleted

- [x] `TweakRadio` (+ its ~100-line test block and the `.twk-seg*` CSS only it used) -- rendered by nothing.
- [x] `SlidersIcon`, `ArrowUpIcon`, `ArrowDownIcon` -- no importers.
- [x] `fmtDur`, `avgMs`, `backendPhase`/`BackendPhase` (+ stale doc comment, `__resetBackendPhaseForTests`) -- only their own tests referenced them. `fetchWithRetry` also loses the unreachable `status === 0` branch (a resolved `fetch()` never yields status 0 without `mode: "no-cors"`).
- [x] `hero.tsx` -- `app.tsx` renders `<HeroAvailability>` inside the `.hero` div directly.
- [x] Dead CSS: `.hero-label`, `.hero-chip-total`, `.group-header`/`.group-title`/`.group-meta*` (verified unreferenced by any `.tsx`).
- [x] Tombstone tests that could never fail: `monitor-list.test.tsx` "does not render a group-header", `top-bar.test.tsx` "no visible tweaks trigger", `dashboard.spec.ts` "event feed is no longer rendered".
- [x] `VITE_BUILD_VERSION` / `VITE_INFORMATIONAL_VERSION` plumbing in `Deucalion.build.ps1` and the `docker-publish.yml` frontend job -- the only `import.meta.env` read anywhere is `DEV` in `logger.ts`.
- [x] `fr` (previous state) on `MonitorCheckedDto` / `MonitorStateChangedDto`, both C# and TS, plus the test fixtures and the key list in `CLAUDE.md`. No production TS ever read it (grep: only test fixtures). The `fix/18-17-sse-resync` branch is not pushed yet, so it could not be checked for a new reader; if that work starts needing the previous state, re-add the field on both sides.
- [x] `MonitorProps` -> `MonitorDto` (7 files).
- [x] `<UseAppHost>false</UseAppHost>` on `Deucalion.Api`; `ErrorOnDuplicatePublishOutputFiles=false` dropped from `Deucalion.Service`. **Note:** this also required dropping the explicit `--self-contained` from the `Build` task in `Deucalion.build.ps1`. Passed on the command line it is a global MSBuild property, so the referenced `Deucalion.Api` became self-contained too, and self-contained + no apphost is `NETSDK1067` (reproduced locally). `PublishAot=true` already implies self-contained for `Deucalion.Service`; the Dockerfile never passed the flag. Proof: `dotnet publish Deucalion.Service -c Release -p:DebugType=None` into a scratch dir succeeds with no duplicate-output error and the output is `Deucalion.Service.exe` (21 MB native), `e_sqlite3.dll`, `appsettings*.json`, `Deucalion.Service.staticwebassets.endpoints.json`, `Deucalion.Api.runtimeconfig.json` -- **no `Deucalion.Api.exe`**. `dotnet run --project Deucalion.Api -c Release --no-build` (what Playwright uses) still boots and serves `/api/configuration`.
- [x] Playwright `globalTeardown` that deletes `src/cs/Deucalion.Api/.e2e-storage` (verified by seeding the directory and running the teardown module directly; `npx playwright test --list` still loads the config).
- [x] `*.tsbuildinfo` added to `.gitignore` -- `npm run build` runs `tsc --build`, which drops `tsconfig.tsbuildinfo` next to `tsconfig.json`.

## Already gone on master

- The stale Tailwind comment in `index.html`.
- `disableLogger` in `logger.ts`.

## Deliberately left (with reasons)

- `Deucalion.Api.runtimeconfig.json` (491 bytes) still lands in the publish folder: it is copied with the project reference and `Deucalion.Api` needs it for `dotnet run`. Inert without an apphost.
- `src/Dockerfile` still sets `ENV VITE_BUILD_VERSION` / `VITE_INFORMATIONAL_VERSION` in the `build-node` stage (same dead plumbing) -- out of scope for this PR; trivial follow-up.
- `docker-publish.yml`: the `frontend` job still declares `needs: version`, which nothing in the job uses any more. Left because only the `env:` block was in scope; can be dropped to let `frontend` start in parallel with `version`.
- Comments in `Deucalion.Api/Application.cs` (~line 31) and `DeucalionJsonContext.cs` (~line 11) still mention `` `fr: 0` `` -- those files are being edited on other branches; follow-up.
- Filesystem-only leftovers that git does not track and this PR cannot delete: `src/cs/Deucalion.Cli/` (orphaned `bin/`/`obj/`), `publish/Deucalion.Api.exe` + `.runtimeconfig.json`, `src/cs/Deucalion.Api/.e2e-storage/`. Delete manually in the working checkout; the teardown prevents the last one from coming back.

## Verification

- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet test -c Release -- --minimum-expected-tests 101`: 155 passed, 8 skipped (network), 0 failed -- 5 runs. (One earlier run, overlapping a concurrent vitest run, reported 1 failure that did not reproduce in the following 5 runs; its name was not captured.)
- `npm run test`: 19 files, 113 tests passed. `npm run lint`: clean. `npm run build`: ok.
