### PR TITLE
fix: SSE resync/keep-alive/bounded channels (#18); surface fatal initial fetch instead of eternal splash (#17)

### DIFF
--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -153,29 +153,49 @@ public static class Application
         // SSE event stream
         app.MapGet("/api/monitors/events", async (MonitorEventBroadcaster broadcaster, HttpContext httpContext) =>
         {
+            // Reconnect delay hinted to EventSource. Browsers default to a few seconds
+            // but the value is implementation-defined; pin it.
+            const int SseRetryMilliseconds = 3000;
+
             var response = httpContext.Response;
             var ct = httpContext.RequestAborted;
 
             response.ContentType = "text/event-stream";
             response.Headers.CacheControl = "no-cache";
-
-            // Write an initial SSE comment to flush the response headers immediately.
-            // TypedResults.ServerSentEvents only flushes on first data event; with a
-            // long check interval this causes EventSource to stay in CONNECTING
-            // state until the first monitor event arrives.
-            await response.WriteAsync(": connected\n\n", ct);
-            await response.Body.FlushAsync(ct);
+            // nginx buffers proxied responses by default, which turns a live stream into
+            // a stall until the buffer fills. This header opts the response out.
+            response.Headers["X-Accel-Buffering"] = "no";
 
             var (reader, writer) = broadcaster.Subscribe();
-            ct.Register(() => broadcaster.Unsubscribe(writer));
-
-            await foreach (var item in reader.ReadAllAsync(ct))
+            try
             {
-                var payload = item.EventType is not null
-                    ? $"event: {item.EventType}\ndata: {item.Data}\n\n"
-                    : $"data: {item.Data}\n\n";
-                await response.WriteAsync(payload, ct);
+                // Write an initial SSE comment to flush the response headers immediately.
+                // TypedResults.ServerSentEvents only flushes on first data event; with a
+                // long check interval this causes EventSource to stay in CONNECTING
+                // state until the first monitor event arrives. The `retry:` field pins
+                // the browser's reconnect delay instead of leaving it to its default.
+                await response.WriteAsync($": connected\nretry: {SseRetryMilliseconds}\n\n", ct);
                 await response.Body.FlushAsync(ct);
+
+                // Frames arrive pre-rendered; keep-alive comments come through the same
+                // channel so an idle stream still carries traffic.
+                await foreach (var frame in reader.ReadAllAsync(ct))
+                {
+                    await response.WriteAsync(frame, ct);
+                    await response.Body.FlushAsync(ct);
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // Client went away. Not an error, and the response has already started,
+                // so there is nothing for the exception handler to do with it anyway.
+            }
+            finally
+            {
+                // The only unsubscribe path. A Register(RequestAborted) callback alone would
+                // leak the writer whenever the loop exits any other way (IOException on a
+                // half-open socket, channel completion at shutdown).
+                broadcaster.Unsubscribe(writer);
             }
         });
 

--- a/src/cs/Deucalion.Api/Services/MonitorEventBroadcaster.cs
+++ b/src/cs/Deucalion.Api/Services/MonitorEventBroadcaster.cs
@@ -3,37 +3,101 @@ using System.Threading.Channels;
 
 namespace Deucalion.Api.Services;
 
+/// <summary>
+/// Fans monitor events out to every connected SSE client as pre-rendered
+/// <c>text/event-stream</c> frames, and emits a keep-alive comment on a fixed
+/// cadence so idle streams are not dropped by proxies.
+/// </summary>
 internal sealed class MonitorEventBroadcaster : IDisposable
 {
-    private readonly HashSet<ChannelWriter<SseItem<string>>> _writers = [];
-    private readonly Lock _lock = new();
+    /// <summary>
+    /// Frames buffered per subscriber before the oldest is dropped. This is a live-status
+    /// stream: a client that cannot keep up is better served by the newest frames than by
+    /// an ever-growing backlog, and the publisher must never block on a wedged socket.
+    /// </summary>
+    internal const int ChannelCapacity = 128;
 
-    public (ChannelReader<SseItem<string>> Reader, ChannelWriter<SseItem<string>> Writer) Subscribe()
+    /// <summary>
+    /// Cadence of the <c>: keep-alive</c> comment. Below the 30-60 s idle timeouts of
+    /// common reverse proxies, and cheap enough that it is sent regardless of traffic.
+    /// </summary>
+    internal static readonly TimeSpan KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    internal const string KeepAliveFrame = ": keep-alive\n\n";
+
+    private readonly HashSet<ChannelWriter<string>> _writers = [];
+    private readonly Lock _lock = new();
+    private readonly ITimer _keepAliveTimer;
+
+    public MonitorEventBroadcaster(TimeProvider timeProvider)
     {
-        var channel = Channel.CreateUnbounded<SseItem<string>>();
+        _keepAliveTimer = timeProvider.CreateTimer(
+            static state => ((MonitorEventBroadcaster)state!).BroadcastFrame(KeepAliveFrame),
+            this,
+            KeepAliveInterval,
+            KeepAliveInterval);
+    }
+
+    /// <summary>Number of live subscriptions. Exposed for tests.</summary>
+    internal int SubscriberCount
+    {
+        get
+        {
+            lock (_lock)
+                return _writers.Count;
+        }
+    }
+
+    /// <summary>Raised (outside the lock) after every Subscribe/Unsubscribe. Exposed for tests.</summary>
+    internal event Action? SubscriptionsChanged;
+
+    public (ChannelReader<string> Reader, ChannelWriter<string> Writer) Subscribe()
+    {
+        var channel = Channel.CreateBounded<string>(new BoundedChannelOptions(ChannelCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+
         lock (_lock)
             _writers.Add(channel.Writer);
+
+        SubscriptionsChanged?.Invoke();
         return (channel.Reader, channel.Writer);
     }
 
-    public void Unsubscribe(ChannelWriter<SseItem<string>> writer)
+    public void Unsubscribe(ChannelWriter<string> writer)
     {
         lock (_lock)
             _writers.Remove(writer);
         writer.TryComplete();
+
+        SubscriptionsChanged?.Invoke();
     }
 
-    public void Broadcast(SseItem<string> item)
+    public void Broadcast(SseItem<string> item) => BroadcastFrame(Render(item));
+
+    /// <summary>
+    /// Renders one event as a <c>text/event-stream</c> block. <see cref="SseItem{T}.EventType"/>
+    /// falls back to <c>message</c> on its own, so there is always an <c>event:</c> line.
+    /// </summary>
+    internal static string Render(SseItem<string> item) =>
+        $"event: {item.EventType}\ndata: {item.Data}\n\n";
+
+    private void BroadcastFrame(string frame)
     {
         lock (_lock)
         {
+            // TryWrite never blocks and, with DropOldest, never fails on a full channel.
             foreach (var writer in _writers)
-                writer.TryWrite(item);
+                writer.TryWrite(frame);
         }
     }
 
     public void Dispose()
     {
+        _keepAliveTimer.Dispose();
         lock (_lock)
         {
             foreach (var writer in _writers)

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -3,10 +3,13 @@ using System.Net.Http.Json;
 using System.Net.ServerSentEvents;
 using System.Text;
 using System.Text.Json;
+using Deucalion.Api.Services;
 using Deucalion.Storage;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Deucalion.Tests.Api;
@@ -207,9 +210,9 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         using var client = _factory.CreateClient();
         var checkedEventReceived = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        // The endpoint writes ": connected\n\n" and flushes as soon as the subscription is
-        // registered, so waiting for that byte is an exact signal -- no sleeping and guessing.
-        var subscribed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // The endpoint writes its preamble and flushes as soon as the subscription is
+        // registered, so waiting for that block is an exact signal -- no sleeping and guessing.
+        var preambleReceived = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(15));
@@ -218,15 +221,14 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         {
             using var response = await client.GetAsync("/api/monitors/events", HttpCompletionOption.ResponseHeadersRead, timeout.Token);
             response.EnsureSuccessStatusCode();
+            Assert.Equal("text/event-stream", response.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("no", Assert.Single(response.Headers.GetValues("X-Accel-Buffering")));
 
             using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
 
             // Read the preamble byte-wise; SseParser skips comment lines, so it cannot
             // surface the ": connected" frame itself.
-            var buffer = new byte[64];
-            var read = await stream.ReadAsync(buffer, timeout.Token);
-            Assert.Contains("connected", Encoding.UTF8.GetString(buffer, 0, read), StringComparison.Ordinal);
-            subscribed.TrySetResult();
+            preambleReceived.TrySetResult(await ReadFrameAsync(stream, timeout.Token));
 
             var parser = SseParser.Create(stream, (_, data) => Encoding.UTF8.GetString(data));
 
@@ -245,7 +247,10 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
             }
         }, timeout.Token);
 
-        await subscribed.Task.WaitAsync(timeout.Token);
+        var preamble = await preambleReceived.Task.WaitAsync(timeout.Token);
+        Assert.Contains(": connected", preamble, StringComparison.Ordinal);
+        // #18: the reconnect delay is pinned instead of left to the browser default.
+        Assert.Contains("retry: 3000", preamble, StringComparison.Ordinal);
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/api/monitors/checkin-main/checkin");
         request.Headers.Add("deucalion-checkin-secret", "test-secret");
@@ -257,6 +262,167 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
 
         timeout.Cancel();
         try { await sseTask; } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task SseStream_ClientAbort_UnsubscribesWithoutAnErrorLog()
+    {
+        // #18: aborting the request must bring the subscriber count back to zero, and the
+        // OperationCanceledException that ends the read loop must not be logged as an error.
+        var logs = new CapturingLoggerProvider();
+        using var factory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureLogging(logging => logging.AddProvider(logs)));
+        using var client = factory.CreateClient();
+
+        var broadcaster = factory.Services.GetRequiredService<MonitorEventBroadcaster>();
+        var unsubscribed = WhenNoSubscribers(broadcaster);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+
+        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(timeout.Token);
+        var response = await client.GetAsync("/api/monitors/events", HttpCompletionOption.ResponseHeadersRead, requestCts.Token);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(requestCts.Token);
+        await ReadFrameAsync(stream, requestCts.Token);
+
+        Assert.Equal(1, broadcaster.SubscriberCount);
+
+        // Abort the request the way a browser closing the tab would.
+        requestCts.Cancel();
+        response.Dispose();
+
+        await unsubscribed.WaitAsync(timeout.Token);
+        Assert.Equal(0, broadcaster.SubscriberCount);
+
+        var errors = logs.Snapshot().Where(e => e.Level >= LogLevel.Error).ToList();
+        Assert.True(errors.Count == 0, "Unexpected error logs:\n" + string.Join("\n", errors.Select(e => $"{e.Category}: {e.Message}")));
+    }
+
+    [Fact]
+    public async Task SseStream_WriteFailureAfterClientWentAway_Unsubscribes()
+    {
+        // #18: unsubscribe must happen however the read loop exits. Here the client drops the
+        // response without cancelling anything and the endpoint only finds out on its next
+        // write. (TestServer still surfaces this through RequestAborted; the endpoint's
+        // finally block is what covers transports that do not.)
+        using var client = _factory.CreateClient();
+
+        var broadcaster = _factory.Services.GetRequiredService<MonitorEventBroadcaster>();
+        var unsubscribed = WhenNoSubscribers(broadcaster);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+
+        var response = await client.GetAsync("/api/monitors/events", HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+        response.EnsureSuccessStatusCode();
+        var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        await ReadFrameAsync(stream, timeout.Token);
+
+        Assert.Equal(1, broadcaster.SubscriberCount);
+
+        // Drop the response without cancelling anything, then force a write.
+        stream.Dispose();
+        response.Dispose();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/monitors/checkin-main/checkin");
+        request.Headers.Add("deucalion-checkin-secret", "test-secret");
+        using var checkIn = await client.SendAsync(request, timeout.Token);
+        checkIn.EnsureSuccessStatusCode();
+
+        await unsubscribed.WaitAsync(timeout.Token);
+        Assert.Equal(0, broadcaster.SubscriberCount);
+    }
+
+    [Fact]
+    public async Task SseStream_SendsKeepAliveWhenIdle()
+    {
+        // Regression for #18: an idle stream carried no bytes after the preamble, so a proxy
+        // could drop it silently. The keep-alive is driven by the injected clock: without it
+        // this test never sees a comment frame and times out.
+        var time = new FakeTimeProvider();
+        using var factory = _factory.WithWebHostBuilder(builder =>
+            builder.ConfigureServices(services => services.AddSingleton<TimeProvider>(time)));
+        using var client = factory.CreateClient();
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
+
+        using var response = await client.GetAsync("/api/monitors/events", HttpCompletionOption.ResponseHeadersRead, timeout.Token);
+        response.EnsureSuccessStatusCode();
+        using var stream = await response.Content.ReadAsStreamAsync(timeout.Token);
+        await ReadFrameAsync(stream, timeout.Token);
+
+        // The engine's start-up probes may interleave MonitorChecked frames; skip those.
+        for (var i = 0; i < 2; i++)
+        {
+            time.Advance(MonitorEventBroadcaster.KeepAliveInterval);
+
+            string frame;
+            do
+            {
+                frame = await ReadFrameAsync(stream, timeout.Token);
+            } while (frame.StartsWith("event:", StringComparison.Ordinal));
+
+            Assert.Equal(MonitorEventBroadcaster.KeepAliveFrame, frame);
+        }
+    }
+
+    private static Task WhenNoSubscribers(MonitorEventBroadcaster broadcaster)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        broadcaster.SubscriptionsChanged += () =>
+        {
+            if (broadcaster.SubscriberCount == 0)
+                tcs.TrySetResult();
+        };
+        return tcs.Task;
+    }
+
+    /// <summary>Reads one <c>text/event-stream</c> block, i.e. up to and including the blank line.</summary>
+    private static Task<string> ReadFrameAsync(Stream stream, CancellationToken cancellationToken) =>
+        ReadUntilAsync(stream, "\n\n", cancellationToken);
+
+    /// <summary>Reads until the accumulated text ends with <paramref name="terminator"/>.</summary>
+    private static async Task<string> ReadUntilAsync(Stream stream, string terminator, CancellationToken cancellationToken)
+    {
+        var text = new StringBuilder();
+        var buffer = new byte[1];
+        while (!text.ToString().EndsWith(terminator, StringComparison.Ordinal))
+        {
+            var read = await stream.ReadAsync(buffer, cancellationToken);
+            if (read == 0)
+                throw new EndOfStreamException($"Stream ended before the terminator. Got: '{text}'");
+            text.Append((char)buffer[0]);
+        }
+        return text.ToString();
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly List<(LogLevel Level, string Category, string Message)> _entries = [];
+
+        /// <summary>Copy taken under the lock: the host keeps logging while the test reads.</summary>
+        public IReadOnlyList<(LogLevel Level, string Category, string Message)> Snapshot()
+        {
+            lock (_entries)
+                return [.. _entries];
+        }
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, _entries);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, List<(LogLevel, string, string)> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (entries)
+                    entries.Add((logLevel, category, formatter(state, exception) + (exception is null ? "" : $" [{exception.GetType().Name}]")));
+            }
+        }
     }
 
     public void Dispose()

--- a/src/cs/Deucalion.Tests/Api/MonitorEventBroadcasterTests.cs
+++ b/src/cs/Deucalion.Tests/Api/MonitorEventBroadcasterTests.cs
@@ -1,5 +1,7 @@
 using System.Net.ServerSentEvents;
+using System.Threading.Channels;
 using Deucalion.Api.Services;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Deucalion.Tests.Api;
@@ -8,29 +10,28 @@ public class MonitorEventBroadcasterTests
 {
     private static SseItem<string> Item(string data) => new(data, "MonitorChecked");
 
-    private static async Task<string> ReadOneAsync(System.Threading.Channels.ChannelReader<SseItem<string>> reader, CancellationToken cancellationToken)
-    {
-        var item = await reader.ReadAsync(cancellationToken);
-        return item.Data;
-    }
+    private static string Frame(string data) => $"event: MonitorChecked\ndata: {data}\n\n";
+
+    private static MonitorEventBroadcaster Create(TimeProvider? timeProvider = null) =>
+        new(timeProvider ?? TimeProvider.System);
 
     [Fact]
     public async Task Broadcast_ReachesEverySubscriber()
     {
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
         var (readerA, _) = broadcaster.Subscribe();
         var (readerB, _) = broadcaster.Subscribe();
 
         broadcaster.Broadcast(Item("hello"));
 
-        Assert.Equal("hello", await ReadOneAsync(readerA, TestContext.Current.CancellationToken));
-        Assert.Equal("hello", await ReadOneAsync(readerB, TestContext.Current.CancellationToken));
+        Assert.Equal(Frame("hello"), await readerA.ReadAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(Frame("hello"), await readerB.ReadAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public void Broadcast_WithNoSubscribers_IsANoOp()
     {
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
 
         // Must not throw -- the engine broadcasts on every probe whether or not
         // a browser is connected.
@@ -38,27 +39,108 @@ public class MonitorEventBroadcasterTests
     }
 
     [Fact]
-    public async Task Broadcast_PreservesOrderAndEventType()
+    public async Task Broadcast_PreservesOrderAndRendersEventType()
     {
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
         var (reader, _) = broadcaster.Subscribe();
 
         broadcaster.Broadcast(new SseItem<string>("first", "MonitorChecked"));
         broadcaster.Broadcast(new SseItem<string>("second", "MonitorStateChanged"));
+        broadcaster.Broadcast(new SseItem<string>("third"));
+
+        Assert.Equal("event: MonitorChecked\ndata: first\n\n", await reader.ReadAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("event: MonitorStateChanged\ndata: second\n\n", await reader.ReadAsync(TestContext.Current.CancellationToken));
+        // SseItem defaults the event type to "message" (the EventSource default).
+        Assert.Equal("event: message\ndata: third\n\n", await reader.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Broadcast_WhenSubscriberIsFull_DropsOldestAndNeverBlocks()
+    {
+        // Regression for #18: the per-subscriber channel was unbounded, so a wedged client
+        // accumulated every event forever. With a bounded DropOldest channel the publisher
+        // still returns immediately and the reader sees only the newest frames.
+        using var broadcaster = Create();
+        var (reader, _) = broadcaster.Subscribe();
+
+        const int overflow = 10;
+        var total = MonitorEventBroadcaster.ChannelCapacity + overflow;
+
+        // Synchronous by construction: were the channel in Wait mode this would either
+        // hang or, with TryWrite, silently drop the *newest* frames instead.
+        for (var i = 0; i < total; i++)
+            broadcaster.Broadcast(Item($"event-{i}"));
+
+        Assert.Equal(MonitorEventBroadcaster.ChannelCapacity, reader.Count);
 
         var first = await reader.ReadAsync(TestContext.Current.CancellationToken);
-        var second = await reader.ReadAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(Frame($"event-{overflow}"), first);
 
-        Assert.Equal("first", first.Data);
-        Assert.Equal("MonitorChecked", first.EventType);
-        Assert.Equal("second", second.Data);
-        Assert.Equal("MonitorStateChanged", second.EventType);
+        string last = first;
+        while (reader.TryRead(out var frame))
+            last = frame;
+        Assert.Equal(Frame($"event-{total - 1}"), last);
+    }
+
+    [Fact]
+    public async Task KeepAlive_IsBroadcastOnTheClockWithNoEvents()
+    {
+        // Regression for #18: an idle stream never carried any bytes after ": connected",
+        // so proxies dropped it. The keep-alive is driven by the injected clock.
+        var time = new FakeTimeProvider();
+        using var broadcaster = Create(time);
+        var (reader, _) = broadcaster.Subscribe();
+
+        time.Advance(MonitorEventBroadcaster.KeepAliveInterval - TimeSpan.FromMilliseconds(1));
+        Assert.Equal(0, reader.Count);
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
+        Assert.Equal(MonitorEventBroadcaster.KeepAliveFrame, await reader.ReadAsync(TestContext.Current.CancellationToken));
+
+        time.Advance(MonitorEventBroadcaster.KeepAliveInterval);
+        Assert.Equal(MonitorEventBroadcaster.KeepAliveFrame, await reader.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void KeepAlive_StopsAfterDispose()
+    {
+        var time = new FakeTimeProvider();
+        var broadcaster = Create(time);
+        var (reader, _) = broadcaster.Subscribe();
+
+        broadcaster.Dispose();
+        time.Advance(MonitorEventBroadcaster.KeepAliveInterval * 3);
+
+        // Channel is complete and holds nothing: no timer fired after Dispose.
+        Assert.True(reader.Completion.IsCompleted);
+        Assert.Equal(0, reader.Count);
+    }
+
+    [Fact]
+    public void SubscriberCount_TracksSubscribeAndUnsubscribe()
+    {
+        using var broadcaster = Create();
+        var changes = 0;
+        broadcaster.SubscriptionsChanged += () => changes++;
+
+        Assert.Equal(0, broadcaster.SubscriberCount);
+
+        var (_, writerA) = broadcaster.Subscribe();
+        var (_, writerB) = broadcaster.Subscribe();
+        Assert.Equal(2, broadcaster.SubscriberCount);
+
+        broadcaster.Unsubscribe(writerA);
+        Assert.Equal(1, broadcaster.SubscriberCount);
+
+        broadcaster.Unsubscribe(writerB);
+        Assert.Equal(0, broadcaster.SubscriberCount);
+        Assert.Equal(4, changes);
     }
 
     [Fact]
     public async Task Unsubscribe_StopsDeliveryAndCompletesTheChannel()
     {
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
         var (readerA, writerA) = broadcaster.Subscribe();
         var (readerB, _) = broadcaster.Subscribe();
 
@@ -66,9 +148,9 @@ public class MonitorEventBroadcasterTests
         broadcaster.Broadcast(Item("after-unsubscribe"));
 
         // A completes with nothing; B still receives.
-        await Assert.ThrowsAsync<System.Threading.Channels.ChannelClosedException>(
+        await Assert.ThrowsAsync<ChannelClosedException>(
             async () => await readerA.ReadAsync(TestContext.Current.CancellationToken));
-        Assert.Equal("after-unsubscribe", await ReadOneAsync(readerB, TestContext.Current.CancellationToken));
+        Assert.Equal(Frame("after-unsubscribe"), await readerB.ReadAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -76,39 +158,40 @@ public class MonitorEventBroadcasterTests
     {
         // A disconnecting client should still be able to drain what it was sent;
         // TryComplete finishes the channel rather than discarding its buffer.
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
         var (reader, writer) = broadcaster.Subscribe();
 
         broadcaster.Broadcast(Item("queued"));
         broadcaster.Unsubscribe(writer);
 
-        Assert.Equal("queued", await ReadOneAsync(reader, TestContext.Current.CancellationToken));
+        Assert.Equal(Frame("queued"), await reader.ReadAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public void Unsubscribe_IsIdempotent()
     {
-        // The SSE endpoint registers Unsubscribe on RequestAborted; a second call
-        // after the stream already ended must not throw.
-        using var broadcaster = new MonitorEventBroadcaster();
+        // The SSE endpoint unsubscribes in a finally block; a second call after the
+        // stream already ended must not throw.
+        using var broadcaster = Create();
         var (_, writer) = broadcaster.Subscribe();
 
         broadcaster.Unsubscribe(writer);
         broadcaster.Unsubscribe(writer);
+        Assert.Equal(0, broadcaster.SubscriberCount);
     }
 
     [Fact]
     public async Task Dispose_CompletesEverySubscriber()
     {
-        var broadcaster = new MonitorEventBroadcaster();
+        var broadcaster = Create();
         var (readerA, _) = broadcaster.Subscribe();
         var (readerB, _) = broadcaster.Subscribe();
 
         broadcaster.Dispose();
 
-        await Assert.ThrowsAsync<System.Threading.Channels.ChannelClosedException>(
+        await Assert.ThrowsAsync<ChannelClosedException>(
             async () => await readerA.ReadAsync(TestContext.Current.CancellationToken));
-        await Assert.ThrowsAsync<System.Threading.Channels.ChannelClosedException>(
+        await Assert.ThrowsAsync<ChannelClosedException>(
             async () => await readerB.ReadAsync(TestContext.Current.CancellationToken));
     }
 
@@ -117,7 +200,7 @@ public class MonitorEventBroadcasterTests
     {
         // Subscribe/Unsubscribe run on request threads while the engine broadcasts
         // from its own loop, so the lock has to hold up under concurrency.
-        using var broadcaster = new MonitorEventBroadcaster();
+        using var broadcaster = Create();
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
         cts.CancelAfter(TimeSpan.FromSeconds(10));
 
@@ -143,6 +226,6 @@ public class MonitorEventBroadcasterTests
         // A subscriber added afterwards still works.
         var (reader, _) = broadcaster.Subscribe();
         broadcaster.Broadcast(Item("still-alive"));
-        Assert.Equal("still-alive", await ReadOneAsync(reader, cts.Token));
+        Assert.Equal(Frame("still-alive"), await reader.ReadAsync(cts.Token));
     }
 }

--- a/src/ts/deucalion-ui/src/app.test.tsx
+++ b/src/ts/deucalion-ui/src/app.test.tsx
@@ -1,0 +1,59 @@
+import { render, waitFor } from "@solidjs/testing-library";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __resetMonitorsForTests, refetchMonitors } from "./stores/monitors-store";
+import { App } from "./app";
+
+// index.html ships the splash; the app only hides it. Recreate it per test.
+const mountSplash = (): HTMLElement => {
+  const splash = document.createElement("div");
+  splash.id = "splash";
+  document.body.appendChild(splash);
+  return splash;
+};
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+describe("<App> splash lifecycle", () => {
+  let splash: HTMLElement;
+
+  beforeEach(() => {
+    __resetMonitorsForTests();
+    splash = mountSplash();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    splash.remove();
+  });
+
+  it("hides the splash once both resources resolve", async () => {
+    // The setup-file fetch stub answers both /api/configuration and /api/monitors.
+    refetchMonitors();
+    render(() => <App />);
+
+    await waitFor(() => { expect(splash).toHaveClass("hidden"); });
+    expect(document.querySelector(".brand-name")?.textContent).not.toBe("Something went wrong");
+  });
+
+  it("surfaces a fatal /api/monitors fetch instead of hanging on the splash (#17)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.endsWith("/api/monitors")) return new Response("nope", { status: 404, statusText: "Not Found" });
+      return jsonResponse({ pageTitle: "Test" });
+    });
+
+    // Re-run the initial fetch against the 404 stub. 4xx is fatal (no retry), so
+    // the resource rejects; before the fix nothing ever read it and the rejection
+    // was swallowed.
+    refetchMonitors();
+    render(() => <App />);
+
+    await waitFor(() => {
+      expect(document.querySelector(".brand-name")?.textContent).toBe("Something went wrong");
+    });
+    expect(document.querySelector("pre.mono")?.textContent).toContain("HTTP 404");
+    expect(splash).toHaveClass("hidden");
+  });
+});

--- a/src/ts/deucalion-ui/src/app.tsx
+++ b/src/ts/deucalion-ui/src/app.tsx
@@ -1,7 +1,7 @@
 import { createEffect, ErrorBoundary, onMount, Show, type Component } from "solid-js";
 
 import { configuration } from "./stores/configuration-store";
-import { monitorsLoaded } from "./stores/monitors-store";
+import { monitorsLoaded, monitorsResource } from "./stores/monitors-store";
 
 import { TopBar } from "./components/top-bar";
 import { HeroAvailability } from "./components/hero/hero-availability";
@@ -33,27 +33,36 @@ const Crashed: Component<{ err: unknown }> = (props) => {
   );
 };
 
-export const App: Component = () => {
-  const ready = (): boolean => Boolean(configuration() && monitorsLoaded());
+// Everything that decides readiness lives *inside* the ErrorBoundary. Both
+// resources are read here: a rejected resource only rethrows on read, so a
+// fatal /api/monitors fetch that nothing reads would leave the splash up
+// forever with no error surfaced (#17). Reading it from a computation owned
+// by the boundary routes the rethrow to the fallback.
+const Dashboard: Component = () => {
+  const ready = (): boolean => Boolean(configuration() && monitorsResource() && monitorsLoaded());
 
   createEffect(() => {
     if (ready()) hideSplash();
   });
 
   return (
-    <ErrorBoundary fallback={(err: unknown) => <Crashed err={err} />}>
-      <Show when={ready()}>
-        <div class="shell">
-          <TopBar />
-          <div class="hero">
-            <HeroAvailability />
-          </div>
-          <MonitorList />
-          <Footer />
+    <Show when={ready()}>
+      <div class="shell">
+        <TopBar />
+        <div class="hero">
+          <HeroAvailability />
         </div>
-      </Show>
-      <ToastStack />
-      <TweaksPanel />
-    </ErrorBoundary>
+        <MonitorList />
+        <Footer />
+      </div>
+    </Show>
   );
 };
+
+export const App: Component = () => (
+  <ErrorBoundary fallback={(err: unknown) => <Crashed err={err} />}>
+    <Dashboard />
+    <ToastStack />
+    <TweaksPanel />
+  </ErrorBoundary>
+);

--- a/src/ts/deucalion-ui/src/stores/monitors-store.ts
+++ b/src/ts/deucalion-ui/src/stores/monitors-store.ts
@@ -26,7 +26,7 @@ const fetchMonitors = async (): Promise<MonitorDto[]> => {
   return await response.json() as MonitorDto[];
 };
 
-const [monitorsResource] = createResource(async () => {
+const [monitorsResource, { refetch }] = createResource(async () => {
   const list = await fetchMonitors();
   setState(
     produce((s) => {
@@ -44,8 +44,18 @@ const [monitorsResource] = createResource(async () => {
 
 // eslint-disable-next-line solid/reactivity
 export const monitors = state;
+
+// Consumers that decide whether the app is "ready" must read the resource
+// itself, not just `loaded`: Solid stores a resource's rejection and only
+// rethrows on read, so a fatal fetch (4xx) that nobody reads is swallowed
+// and the splash never goes away (#17).
 export { monitorsResource };
 export const monitorsLoaded = (): boolean => state.loaded;
+
+// Re-run the initial fetch. Used by the SSE layer after a reconnect: events
+// missed while the stream was down would otherwise leave a permanent hole
+// in the heartbeat strip and stale stats (#18).
+export const refetchMonitors = (): void => { void refetch(); };
 
 export const monitorList = (): MonitorDto[] => state.order.map((name) => state.byName[name]);
 

--- a/src/ts/deucalion-ui/src/stores/sse.test.ts
+++ b/src/ts/deucalion-ui/src/stores/sse.test.ts
@@ -59,10 +59,28 @@ const lastSource = (): FakeEventSource => {
   return last;
 };
 
+// Answers the resync fetch. Stubbed per test (rather than relying on the
+// setup-file default) so a call count can be asserted, and never unstubbed
+// wholesale: `vi.unstubAllGlobals()` would also drop the setup-file fetch stub
+// and leave real (failing, endlessly retrying) fetches running in the background.
+const okFetch = (): ReturnType<typeof vi.fn> =>
+  vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const body = url.endsWith("/api/monitors") ? "[]" : "{}";
+    return new Response(body, { status: 200, headers: { "content-type": "application/json" } });
+  });
+
+const monitorsFetches = (spy: ReturnType<typeof vi.fn>): number =>
+  spy.mock.calls.filter(([input]) => String(input).endsWith("/api/monitors")).length;
+
 describe("connectSSE()", () => {
+  let fetchStub: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     FakeEventSource.instances = [];
     vi.stubGlobal("EventSource", FakeEventSource);
+    fetchStub = okFetch();
+    vi.stubGlobal("fetch", fetchStub);
     __resetMonitorsForTests();
     __resetToastsForTests();
     __resetSseForTests();
@@ -70,7 +88,7 @@ describe("connectSSE()", () => {
 
   afterEach(() => {
     __resetSseForTests();
-    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("opens an EventSource against the configured events URL", () => {
@@ -119,5 +137,121 @@ describe("connectSSE()", () => {
     expect(es.readyState).toBe(FakeEventSource.CONNECTING);
     dispose();
     expect(es.readyState).toBe(FakeEventSource.CLOSED);
+  });
+
+  describe("resync after reconnect (#18)", () => {
+    it("does not refetch on the first open", () => {
+      connectSSE();
+      lastSource().emitOpen();
+      expect(monitorsFetches(fetchStub)).toBe(0);
+    });
+
+    it("refetches /api/monitors exactly once when the browser reconnects", () => {
+      connectSSE();
+      const es = lastSource();
+      es.emitOpen();
+
+      // Browser-driven retry: error while CONNECTING, then open again on the same source.
+      es.readyState = FakeEventSource.CONNECTING;
+      es.emit("error");
+      expect(sseStatus()).toBe("connecting");
+      es.emitOpen();
+
+      expect(sseStatus()).toBe("open");
+      expect(monitorsFetches(fetchStub)).toBe(1);
+    });
+
+    it("refetches once per reconnect, not once per event", async () => {
+      connectSSE();
+      const es = lastSource();
+      es.emitOpen();
+      es.emit("error");
+      es.emitOpen();
+      // Solid coalesces refetch() calls issued in the same microtask; a real
+      // second reconnect is always at least a tick later.
+      await Promise.resolve();
+      es.emit("error");
+      es.emitOpen();
+      expect(monitorsFetches(fetchStub)).toBe(2);
+    });
+  });
+
+  describe("fatal error state (#18)", () => {
+    it("sets status to error when the source is CLOSED and lets connectSSE() reconnect", () => {
+      connectSSE();
+      const first = lastSource();
+      first.emitOpen();
+
+      first.readyState = FakeEventSource.CLOSED;
+      first.emit("error");
+      expect(sseStatus()).toBe("error");
+
+      // Before the fix activeSource still pointed at the dead source and this was a no-op.
+      connectSSE();
+      expect(FakeEventSource.instances).toHaveLength(2);
+      expect(sseStatus()).toBe("connecting");
+    });
+
+    it("treats the open of the replacement source as a reconnect and resyncs", () => {
+      connectSSE();
+      const first = lastSource();
+      first.emitOpen();
+      first.readyState = FakeEventSource.CLOSED;
+      first.emit("error");
+
+      connectSSE();
+      lastSource().emitOpen();
+
+      expect(sseStatus()).toBe("open");
+      expect(monitorsFetches(fetchStub)).toBe(1);
+    });
+
+    it("reconnects when the tab becomes visible after a fatal error", () => {
+      connectSSE();
+      const first = lastSource();
+      first.emitOpen();
+      first.readyState = FakeEventSource.CLOSED;
+      first.emit("error");
+      expect(sseStatus()).toBe("error");
+
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(FakeEventSource.instances).toHaveLength(2);
+      expect(sseStatus()).toBe("connecting");
+    });
+
+    it("does not reconnect on visibility change while the browser is still retrying", () => {
+      connectSSE();
+      const es = lastSource();
+      es.emitOpen();
+      es.emit("error"); // readyState stays OPEN/CONNECTING: browser handles it
+      expect(sseStatus()).toBe("connecting");
+
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(FakeEventSource.instances).toHaveLength(1);
+    });
+  });
+
+  it("ignores a malformed payload and keeps listening", () => {
+    __seedMonitorsForTests([buildMonitor({ name: "m1", events: [] })]);
+    connectSSE();
+    const es = lastSource();
+
+    expect(() => { es.emit("MonitorChecked", "{not json"); }).not.toThrow();
+    expect(() => { es.emit("MonitorStateChanged", "{not json"); }).not.toThrow();
+    expect(toastList()).toHaveLength(0);
+
+    es.emit("MonitorChecked", {
+      n: "m1",
+      at: 100,
+      fr: MonitorState.Up,
+      st: MonitorState.Down,
+      ms: 250,
+      ns: { lastState: MonitorState.Down, availability: 0 },
+    });
+    expect(monitors.byName.m1.events[0]).toMatchObject({ at: 100, st: MonitorState.Down });
   });
 });

--- a/src/ts/deucalion-ui/src/stores/sse.ts
+++ b/src/ts/deucalion-ui/src/stores/sse.ts
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js";
 import { API_EVENTS_URL } from "../configuration";
 import type { MonitorCheckedDto, MonitorStateChangedDto } from "../services/deucalion-types";
 import * as logger from "../services/logger";
-import { mergeChecked } from "./monitors-store";
+import { mergeChecked, refetchMonitors } from "./monitors-store";
 import { showStateChangeToast } from "./toast-store";
 
 export type SseStatus = "connecting" | "open" | "error";
@@ -13,12 +13,47 @@ export const sseStatus = status;
 
 let activeSource: EventSource | null = null;
 
+// True once any EventSource in this page's lifetime has reached `open`. A
+// later `open` -- on the same source after the browser's automatic retry, or
+// on a new source after a fatal error -- is a reconnect, and every event
+// broadcast in between was missed (#18).
+let hasOpenedBefore = false;
+
+let visibilityListenerInstalled = false;
+
 export const __resetSseForTests = (): void => {
   if (activeSource !== null) {
     activeSource.close();
     activeSource = null;
   }
+  hasOpenedBefore = false;
   setStatus("connecting");
+};
+
+// Parse an SSE payload, returning null (and logging) instead of throwing:
+// one malformed frame must not take the listener down with it.
+const parsePayload = (e: MessageEvent<string>): unknown => {
+  try {
+    return JSON.parse(e.data) as unknown;
+  } catch (err) {
+    logger.warn(`SSE: ignoring malformed ${e.type} payload`, err);
+    return null;
+  }
+};
+
+// When the tab comes back into view after a fatal SSE error, try again. The
+// browser only retries on its own while the source is CONNECTING; a CLOSED
+// source stays closed. Reconnecting through connectSSE() also resyncs the
+// store via the reconnect path in handleOpen.
+const installVisibilityReconnect = (): void => {
+  if (visibilityListenerInstalled || typeof document === "undefined") return;
+  visibilityListenerInstalled = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible" && status() === "error") {
+      logger.log("SSE: tab visible after error; reconnecting");
+      connectSSE();
+    }
+  });
 };
 
 export const connectSSE = (): (() => void) => {
@@ -26,28 +61,55 @@ export const connectSSE = (): (() => void) => {
     return () => { /* no-op: already connected */ };
   }
 
+  installVisibilityReconnect();
+
   setStatus("connecting");
   const es = new EventSource(API_EVENTS_URL);
   activeSource = es;
 
   const handleChecked = (e: MessageEvent<string>): void => {
-    const event = JSON.parse(e.data) as MonitorCheckedDto;
-    mergeChecked(event);
+    const event = parsePayload(e) as MonitorCheckedDto | null;
+    if (event) mergeChecked(event);
   };
 
   const handleStateChanged = (e: MessageEvent<string>): void => {
-    const event = JSON.parse(e.data) as MonitorStateChangedDto;
-    showStateChangeToast(event);
+    const event = parsePayload(e) as MonitorStateChangedDto | null;
+    if (event) showStateChangeToast(event);
   };
 
   const handleOpen = (): void => {
-    logger.log("SSE connection opened");
+    if (hasOpenedBefore) {
+      // Events broadcast while we were disconnected are gone for good; the
+      // REST snapshot is the only way to close the gap in the heartbeat strip.
+      logger.log("SSE connection re-opened; resyncing monitors");
+      refetchMonitors();
+    } else {
+      logger.log("SSE connection opened");
+    }
+    hasOpenedBefore = true;
     setStatus("open");
   };
 
   const handleError = (): void => {
-    logger.warn("SSE connection error");
-    setStatus(es.readyState === EventSource.CLOSED ? "error" : "connecting");
+    if (es.readyState === EventSource.CLOSED) {
+      // Fatal: the browser will not retry this source. Drop it so a later
+      // connectSSE() (visibility change, retry affordance) can create a new one.
+      logger.warn("SSE connection closed");
+      dispose();
+      setStatus("error");
+    } else {
+      logger.warn("SSE connection error; browser is retrying");
+      setStatus("connecting");
+    }
+  };
+
+  const dispose = (): void => {
+    es.removeEventListener("MonitorChecked", handleChecked);
+    es.removeEventListener("MonitorStateChanged", handleStateChanged);
+    es.removeEventListener("open", handleOpen);
+    es.removeEventListener("error", handleError);
+    es.close();
+    if (activeSource === es) activeSource = null;
   };
 
   es.addEventListener("MonitorChecked", handleChecked);
@@ -55,12 +117,5 @@ export const connectSSE = (): (() => void) => {
   es.addEventListener("open", handleOpen);
   es.addEventListener("error", handleError);
 
-  return (): void => {
-    es.removeEventListener("MonitorChecked", handleChecked);
-    es.removeEventListener("MonitorStateChanged", handleStateChanged);
-    es.removeEventListener("open", handleOpen);
-    es.removeEventListener("error", handleError);
-    es.close();
-    activeSource = null;
-  };
+  return dispose;
 };


### PR DESCRIPTION
Closes #18
Closes #17

## #18 — SSE: no resync after reconnect, no keep-alive, unbounded channel, writer leak

### Root cause
- **Server**: one unbounded channel per SSE subscriber; the only unsubscribe path was a `RequestAborted` callback; nothing after `: connected` was ever written on an idle stream; no `retry:` hint; a normal disconnect escaped the endpoint as `OperationCanceledException`.
- **Client**: after a browser-driven EventSource reconnect nothing re-fetched `/api/monitors`, so every `MonitorChecked` missed while disconnected became a permanent hole in the heartbeat strip. A `CLOSED` source stayed in `activeSource`, so every later `connectSSE()` was a no-op.

### Fix
`MonitorEventBroadcaster` (`src/cs/Deucalion.Api/Services/MonitorEventBroadcaster.cs`)
- Per-subscriber `Channel.CreateBounded<string>(128) { FullMode = DropOldest, SingleReader = true }`. `TryWrite` never blocks and never fails; a wedged client only loses stale frames.
- Frames are rendered once (`event: …\ndata: …\n\n`) in the broadcaster; a `: keep-alive\n\n` comment is broadcast every 15 s by a `TimeProvider`-driven timer (injected via DI, so `FakeTimeProvider` drives it in tests).
- `SubscriberCount` / `SubscriptionsChanged` exposed `internal` for tests (InternalsVisibleTo already exists).

`/api/monitors/events` handler (`Application.cs`, that region only)
- Preamble is now `: connected\nretry: 3000\n\n`; `X-Accel-Buffering: no` for nginx.
- `try { … } catch (OperationCanceledException) when (ct.IsCancellationRequested) { } finally { broadcaster.Unsubscribe(writer); }` — unsubscribe happens however the loop exits; a client disconnect is no longer an exception leaving the endpoint.

`sse.ts` / `monitors-store.ts`
- `refetchMonitors()` exported (Solid's `refetch`). `open` after any earlier `open` in the page's lifetime re-fetches `/api/monitors`.
- Fatal error path (`readyState === CLOSED`) disposes the source and clears `activeSource`, so `connectSSE()` can reconnect; `visibilitychange` → visible while in `error` reconnects (and therefore resyncs).
- Malformed JSON is logged and skipped instead of throwing out of the listener.

## #17 — splash hangs forever on a fatal initial `/api/monitors` fetch

### Root cause
Nothing read `monitorsResource()`; only `state.loaded` was consumed. Solid stores a resource's rejection and rethrows on read, so a 4xx from `fetchWithRetry` (deliberately not retried) was swallowed: `ready()` stayed false, the splash never hid, the `ErrorBoundary` never fired.

### Fix
`app.tsx`: readiness now lives in a `<Dashboard>` component owned by the `ErrorBoundary`, and `ready()` reads both resources. The rethrow reaches the boundary's fallback, which hides the splash.

## Tests (all fail before / pass after unless noted)

.NET (`MonitorEventBroadcasterTests`, `ApiIntegrationTests`):
- `Broadcast_WhenSubscriberIsFull_DropsOldestAndNeverBlocks` — capacity+10 broadcasts, publisher returns synchronously, reader sees the newest 128.
- `KeepAlive_IsBroadcastOnTheClockWithNoEvents`, `KeepAlive_StopsAfterDispose` — `FakeTimeProvider`.
- `SubscriberCount_TracksSubscribeAndUnsubscribe`.
- `SseStream_BroadcastsMonitorCheckedEvent_ToConnectedClients` — now also asserts `retry: 3000`, `X-Accel-Buffering`, content type (fails pre-fix on the retry hint).
- `SseStream_SendsKeepAliveWhenIdle` — `FakeTimeProvider` injected through `WithWebHostBuilder`; two advances, two keep-alive comments through the real endpoint.
- `SseStream_ClientAbort_UnsubscribesWithoutAnErrorLog` — subscriber count 1 → 0 after abort, nothing logged at Error (verified via a capturing `ILoggerProvider`).
- `SseStream_WriteFailureAfterClientWentAway_Unsubscribes` — guards the unsubscribe path when the client drops the response without cancelling. Honest note: TestServer still surfaces this via `RequestAborted`, so this one passes before the fix too; the `finally` covers transports that do not.
- The four SSE integration tests were looped 20× locally without a failure (an earlier flake was in the test's own log capture, fixed by snapshotting under the lock).

Frontend (`sse.test.ts`, `app.test.tsx`) — 7 new tests fail on `origin/master`'s `sse.ts`/`app.tsx`, all pass after:
- reconnect refetches `/api/monitors` exactly once (and once per reconnect, not per event); first open does not refetch
- `CLOSED` error sets `error`, `connectSSE()` then creates a new source; its open resyncs
- `visibilitychange` reconnects only from the `error` state
- malformed payload is ignored, the next good event still merges
- `<App>` with `/api/monitors` → 404 renders "Something went wrong … HTTP 404" and hides the splash (pre-fix: times out on the splash); happy path hides the splash once both resources resolve

Local: `dotnet test -c Release` 171 passed / 8 skipped; `npm run test` 123 passed; `npm run lint` clean; `npm run build` ok. Not run locally: `test:e2e` (CI).

Also fixed in passing: `sse.test.ts` called `vi.unstubAllGlobals()`, which also dropped the setup-file `fetch` stub and left real fetches retrying endlessly in the background between tests.
