### PR TITLE
fix: assorted defects from #23 (options validation, CORS, check-in hardening, reserved name, purge/VACUUM, TCP port range)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ curl -X POST \
 - `secret` is **optional**. If you omit it no authentication is performed: anyone who can reach
   the endpoint can mark the monitor UP.
 - Each check-in marks the monitor UP. If none arrives within `intervalToDown`, it goes DOWN.
+- Check-ins are limited to 60 per minute per client address; further ones get `429 Too Many Requests`
+  until the minute is over.
 
 # API
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ A `WARN` probe means "up, but slow". It counts as available: it does not advance
 
 This section defines the individual monitors. Each monitor has a unique name (e.g., `ping-example`) and a type indicated by a YAML tag (e.g., `!ping`).
 
+Monitor names appear in URLs (`/api/monitors/{monitorName}`). The name `events` (in any letter case) is reserved for the event stream endpoint and is rejected at startup.
+
 The following optional parameters are available for all monitors:
 - `group`: A string to group monitors together in the UI.
 - `href`: URL to link to when the monitor name is clicked.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ monitors:
 
 Monitoring behavior is defined in a YAML configuration file (e.g., `deucalion.yaml`).
 
+### Server options
+
+Server settings come from the `Deucalion` configuration section -- as environment variables, `DEUCALION__<NAME>` (see the *Quick start* above). Every option has a default; an invalid value (e.g. a zero interval) stops the server at startup with a `Configuration error` naming the option.
+
+| Option                 | Default            | Description |
+|------------------------|--------------------|-------------|
+| `CONFIGURATIONFILE`    | `deucalion.yaml`   | Path of the YAML configuration file. |
+| `STORAGEPATH`          | `<temp>/Deucalion` | Directory of the SQLite database. |
+| `PAGETITLE`            | `Deucalion status` | Title of the web page. |
+| `EVENTRETENTIONPERIOD` | `30.00:00:00`      | Events older than this are deleted by the purge. |
+| `MAXEVENTSPERMONITOR`  | `100000`           | Newest events kept per monitor; the purge deletes the rest, even if still within the retention period. |
+| `PURGEINTERVAL`        | `1.00:00:00`       | How often the purge runs (it also runs once at startup). |
+
+The purge deletes in chunks of 10,000 rows, so the engine keeps recording events while a large backlog is removed, and then hands the freed pages back to the file system: the database file shrinks. The UI only ever reads the last 120 events per monitor, so `MAXEVENTSPERMONITOR` bounds disk usage without losing anything the dashboard shows.
+
 ### Defaults Section
 
 This optional section allows you to define default values that apply to all monitors, or to all monitors of a specific type, unless overridden in a monitor's configuration. Example:

--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -91,7 +91,7 @@ public static class Application
         builder.Services.AddSingleton<SqliteStorage>(sp =>
         {
             var options = sp.GetRequiredService<DeucalionOptions>();
-            return new SqliteStorage(options.StoragePath);
+            return new SqliteStorage(options.StoragePath, sp.GetRequiredService<TimeProvider>());
         });
         builder.Services.AddSingleton<IStorage>(sp => sp.GetRequiredService<SqliteStorage>());
         builder.Services.TryAddSingleton(TimeProvider.System);

--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -1,4 +1,7 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.RateLimiting;
 using Deucalion.Api.Endpoints;
 using Deucalion.Api.Http;
 using Deucalion.Api.Models;
@@ -11,6 +14,7 @@ using Deucalion.Monitors;
 using Deucalion.Network.Monitors;
 using Deucalion.Storage;
 using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -18,6 +22,9 @@ namespace Deucalion.Api;
 
 public static class Application
 {
+    internal const string CheckInRateLimitPolicy = "checkin";
+    internal const int CheckInRateLimitPerMinute = 60;
+
     public static WebApplicationBuilder ConfigureApplicationBuilder(this WebApplicationBuilder builder)
     {
         // Json.
@@ -39,6 +46,23 @@ public static class Application
 
         // CORS
         builder.Services.AddCors();
+
+        // Check-in rate limiting: the endpoint is unauthenticated (or guarded by a shared
+        // secret) and reachable from anywhere, so bound how fast one client can hammer it.
+        // Partitioned per client IP; a fixed window keeps the bookkeeping to one counter.
+        builder.Services.AddRateLimiter(options =>
+        {
+            options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            options.AddPolicy(CheckInRateLimitPolicy, context =>
+                RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: context.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = CheckInRateLimitPerMinute,
+                        Window = TimeSpan.FromMinutes(1),
+                        QueueLimit = 0,
+                    }));
+        });
 
         // Response compression
         builder.Services.AddResponseCompression(options =>
@@ -100,6 +124,8 @@ public static class Application
             })
         );
 
+        app.UseRateLimiter();
+
         app.UseResponseCompression();
 
         app.Services.GetRequiredService<IStorage>().InitializeAsync().GetAwaiter().GetResult();
@@ -143,11 +169,11 @@ public static class Application
                     return DeucalionResults.NotCheckInMonitor(monitorName, $"/api/monitors/{monitorName}");
                 }
 
-                // No configured secret means no authentication. Compare as strings: the
-                // StringValues overload of '!=' compares counts first, so an empty secret
-                // never matches an absent header.
+                // No configured secret means no authentication. The header is read through
+                // StringValues.ToString(), so an absent header is an empty string and never
+                // matches a non-empty secret.
                 if (!string.IsNullOrEmpty(cim.Secret) &&
-                    !string.Equals(cim.Secret, request.Headers["deucalion-checkin-secret"].ToString(), StringComparison.Ordinal))
+                    !SecretMatches(cim.Secret, request.Headers["deucalion-checkin-secret"].ToString()))
                 {
                     return DeucalionResults.InvalidCheckInSecret(monitorName, $"/api/monitors/{monitorName}");
                 }
@@ -155,7 +181,8 @@ public static class Application
                 cim.CheckIn();
 
                 return Results.Ok();
-            });
+            })
+            .RequireRateLimiting(CheckInRateLimitPolicy);
 
         // SSE event stream
         app.MapGet("/api/monitors/events", async (MonitorEventBroadcaster broadcaster, HttpContext httpContext) =>
@@ -221,6 +248,19 @@ public static class Application
         }
 
         return app;
+    }
+
+    /// <summary>
+    /// Constant-time comparison: string.Equals short-circuits on the first mismatching
+    /// character, which leaks how much of the secret an attacker has right (#23). The length
+    /// check leaks only the length, which FixedTimeEquals requires anyway.
+    /// </summary>
+    private static bool SecretMatches(string expected, string supplied)
+    {
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var suppliedBytes = Encoding.UTF8.GetBytes(supplied);
+        return expectedBytes.Length == suppliedBytes.Length
+            && CryptographicOperations.FixedTimeEquals(expectedBytes, suppliedBytes);
     }
 
     // The frontend's heartbeat strip scales from 60 (mobile) up to 120 ticks

--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -80,6 +80,12 @@ public static class Application
 
     public static WebApplication ConfigureApplication(this WebApplication app)
     {
+        // Before the exception handler, so 500 responses carry CORS headers too. Methods and
+        // headers must be allowed explicitly: with origin only, a preflight for a check-in
+        // (POST + deucalion-checkin-secret) got no Allow-Methods/Allow-Headers and the browser
+        // blocked the call (#23).
+        app.UseCors(x => x.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader());
+
         app.UseExceptionHandler(exceptionHandlerApp =>
             exceptionHandlerApp.Run(async context =>
             {
@@ -93,8 +99,6 @@ public static class Application
                 await Results.Problem().ExecuteAsync(context);
             })
         );
-
-        app.UseCors(x => x.AllowAnyOrigin());
 
         app.UseResponseCompression();
 

--- a/src/cs/Deucalion.Api/Application.cs
+++ b/src/cs/Deucalion.Api/Application.cs
@@ -51,8 +51,9 @@ public static class Application
 
         // Application configuration
         var deucalionOptions = new DeucalionOptions();
-        builder.Configuration.GetSection("Deucalion").Bind(deucalionOptions);
+        builder.Configuration.GetSection(DeucalionOptions.SectionName).Bind(deucalionOptions);
         deucalionOptions.PageTitle ??= "Deucalion status";
+        deucalionOptions.Validate(); // Before anything consumes them: a bad value must not reach the purge timer (#23).
         builder.Services.AddSingleton(_ => deucalionOptions);
 
         var applicationConfiguration = ApplicationConfiguration.ReadFromFile(deucalionOptions.ConfigurationFile ?? "deucalion.yaml");

--- a/src/cs/Deucalion.Api/Options/DeucalionOptions.cs
+++ b/src/cs/Deucalion.Api/Options/DeucalionOptions.cs
@@ -1,7 +1,12 @@
-﻿namespace Deucalion.Api.Options;
+﻿using Deucalion.Application.Configuration;
+
+namespace Deucalion.Api.Options;
 
 public sealed class DeucalionOptions
 {
+    /// <summary>The configuration section these options are bound from (<c>DEUCALION__*</c> as environment variables).</summary>
+    public const string SectionName = "Deucalion";
+
     // Server-only
     public string? ConfigurationFile { get; set; }
     public string? StoragePath { get; set; }
@@ -9,6 +14,42 @@ public sealed class DeucalionOptions
     public TimeSpan EventRetentionPeriod { get; set; } = TimeSpan.FromDays(30); // Default to 30 days
     public TimeSpan PurgeInterval { get; set; } = TimeSpan.FromHours(24); // Default to once a day
 
+    /// <summary>
+    /// Newest events kept per monitor; older ones are deleted by the purge even if still within
+    /// <see cref="EventRetentionPeriod"/>. Bounds the database size: the UI only ever reads the
+    /// last 120 events and computes stats over the last 60, so nothing is lost by capping.
+    /// </summary>
+    public int MaxEventsPerMonitor { get; set; } = 100_000;
+
     // Client-only
     public string? PageTitle { get; set; }
+
+    /// <summary>
+    /// Fails fast on values that would otherwise take the host down later with an opaque error --
+    /// e.g. <c>DEUCALION__PURGEINTERVAL=00:00:00</c> made <c>PeriodicTimer</c> throw inside the
+    /// purge service, and the default <c>BackgroundServiceExceptionBehavior.StopHost</c> then
+    /// stopped the whole application.
+    /// </summary>
+    /// <exception cref="ConfigurationErrorException">A value is out of range; the message names the option.</exception>
+    public void Validate()
+    {
+        RequirePositive(nameof(PurgeInterval), PurgeInterval);
+        RequirePositive(nameof(EventRetentionPeriod), EventRetentionPeriod);
+
+        if (MaxEventsPerMonitor <= 0)
+        {
+            throw Invalid(nameof(MaxEventsPerMonitor), MaxEventsPerMonitor);
+        }
+    }
+
+    private static void RequirePositive(string name, TimeSpan value)
+    {
+        if (value <= TimeSpan.Zero)
+        {
+            throw Invalid(name, value);
+        }
+    }
+
+    private static ConfigurationErrorException Invalid(string name, object value) =>
+        new($"Option '{SectionName}:{name}' must be a positive value, but was '{value}'.");
 }

--- a/src/cs/Deucalion.Api/Services/PurgeBackgroundService.cs
+++ b/src/cs/Deucalion.Api/Services/PurgeBackgroundService.cs
@@ -33,8 +33,8 @@ internal class PurgeBackgroundService(
     {
         try
         {
-            logger.LogInformation("Starting periodic database purge (Retention: {RetentionPeriod})...", options.EventRetentionPeriod);
-            var deletedCount = await storage.PurgeOldEventsAsync(options.EventRetentionPeriod, cancellationToken);
+            logger.LogInformation("Starting periodic database purge (Retention: {RetentionPeriod}, MaxEventsPerMonitor: {MaxEventsPerMonitor})...", options.EventRetentionPeriod, options.MaxEventsPerMonitor);
+            var deletedCount = await storage.PurgeOldEventsAsync(options.EventRetentionPeriod, options.MaxEventsPerMonitor, cancellationToken);
             logger.LogInformation("Database purge completed. Deleted {DeletedCount} old events.", deletedCount);
         }
         catch (OperationCanceledException)

--- a/src/cs/Deucalion.Application/Configuration/ApplicationConfiguration.cs
+++ b/src/cs/Deucalion.Application/Configuration/ApplicationConfiguration.cs
@@ -30,7 +30,16 @@ public record ApplicationConfiguration
         public const string ConfigurationMonitorCannotBeEmpty = "Monitor '{0}' cannot be empty.";
         public const string ConfigurationInvalidTimeSpan = "Monitor '{0}': '{1}' must be a positive value, but was '{2}'.";
         public const string ConfigurationUnknownMonitorType = "Monitor '{0}': missing or unknown type tag. Expected one of: !ping, !tcp, !dns, !http, !checkin.";
+        public const string ConfigurationReservedMonitorName = "Monitor '{0}': the name is reserved (it would clash with the '/api/monitors/{1}' route). Choose another name.";
     }
+
+    /// <summary>
+    /// Monitor names that collide with literal segments under <c>/api/monitors/</c>. A monitor
+    /// named 'events' was reachable in the UI but not at <c>/api/monitors/events</c>, which the
+    /// SSE stream owns (#23). Compared case-insensitively: routing is case-insensitive too.
+    /// </summary>
+    public static readonly IReadOnlySet<string> ReservedMonitorNames =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "events" };
 
     public ConfigurationDefaults? Defaults { get; set; }
 
@@ -101,6 +110,11 @@ public record ApplicationConfiguration
             if (monitor.Value.GetType() == typeof(PullMonitorConfiguration))
             {
                 throw new ConfigurationErrorException(string.Format(Messages.ConfigurationUnknownMonitorType, monitor.Key));
+            }
+
+            if (ReservedMonitorNames.Contains(monitor.Key))
+            {
+                throw new ConfigurationErrorException(string.Format(Messages.ConfigurationReservedMonitorName, monitor.Key, monitor.Key.ToLowerInvariant()));
             }
 
             // Interpolate ${MONITOR_NAME} placeholders

--- a/src/cs/Deucalion.Network/Configuration/TcpMonitorConfiguration.cs
+++ b/src/cs/Deucalion.Network/Configuration/TcpMonitorConfiguration.cs
@@ -8,6 +8,8 @@ public record TcpMonitorConfiguration : PullMonitorConfiguration
     [Required]
     public required string Host { get; set; }
 
-    [Required]
+    // [Required] is a no-op on a non-nullable int: 'port: 0' or 'port: 99999' passed validation
+    // and then threw ArgumentOutOfRangeException on every probe (#23). Range does the real check.
+    [Range(1, 65535)]
     public required int Port { get; set; }
 }

--- a/src/cs/Deucalion.Storage/IStorage.cs
+++ b/src/cs/Deucalion.Storage/IStorage.cs
@@ -10,5 +10,10 @@ public interface IStorage
 
     Task SaveEventAsync(string monitorName, StoredEvent storedEvent, CancellationToken cancellationToken = default);
 
-    Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Deletes events older than <paramref name="retentionPeriod"/> and, per monitor, any beyond
+    /// the newest <paramref name="maxEventsPerMonitor"/>. Zero or negative disables that criterion.
+    /// </summary>
+    /// <returns>The number of rows deleted.</returns>
+    Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, int maxEventsPerMonitor, CancellationToken cancellationToken = default);
 }

--- a/src/cs/Deucalion.Storage/SqliteStorage.cs
+++ b/src/cs/Deucalion.Storage/SqliteStorage.cs
@@ -6,11 +6,21 @@ public sealed class SqliteStorage : IStorage, IDisposable
 {
     private const string EventsTableName = "Events";
 
+    /// <summary>
+    /// Rows deleted per statement by <see cref="PurgeOldEventsAsync(TimeSpan, int, CancellationToken)"/>.
+    /// Each chunk is its own implicit transaction, so the write lock is released between chunks
+    /// and the engine keeps saving events while a large backlog is purged.
+    /// </summary>
+    public const int PurgeChunkSize = 10_000;
+
     private readonly string _connectionString;
     private readonly string _dbFile;
+    private readonly TimeProvider _timeProvider;
 
-    public SqliteStorage(string? storagePath = null)
+    public SqliteStorage(string? storagePath = null, TimeProvider? timeProvider = null)
     {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+
         var dbPath = storagePath ?? Path.Combine(Path.GetTempPath(), "Deucalion");
         // Ensure the directory exists
         Directory.CreateDirectory(dbPath);
@@ -31,6 +41,11 @@ public sealed class SqliteStorage : IStorage, IDisposable
 
         using var command = connection.CreateCommand();
         command.CommandText = $"""
+            -- Lets the purge hand free pages back to the OS with 'PRAGMA incremental_vacuum'
+            -- instead of a full VACUUM. Only takes effect on a database that has no tables yet;
+            -- older databases are converted once by the first purge that deletes rows.
+            PRAGMA auto_vacuum=INCREMENTAL;
+
             -- Enable Write-Ahead Logging for better concurrency
             PRAGMA journal_mode=WAL;
 
@@ -233,35 +248,145 @@ public sealed class SqliteStorage : IStorage, IDisposable
     }
 
     /// <summary>
-    /// Deletes events older than the specified retention period.
+    /// Deletes events older than <paramref name="retentionPeriod"/>. No per-monitor row cap.
     /// </summary>
-    /// <param name="retentionPeriod">The maximum age of events to keep.</param>
+    public Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, CancellationToken cancellationToken = default) =>
+        PurgeOldEventsAsync(retentionPeriod, maxEventsPerMonitor: 0, cancellationToken);
+
+    /// <summary>
+    /// Deletes events older than <paramref name="retentionPeriod"/> and, per monitor, any beyond
+    /// the newest <paramref name="maxEventsPerMonitor"/>; then returns the freed pages to the OS.
+    /// </summary>
+    /// <param name="retentionPeriod">The maximum age of events to keep; zero or negative disables the age purge.</param>
+    /// <param name="maxEventsPerMonitor">Newest events kept per monitor; zero or negative disables the cap.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The number of rows deleted.</returns>
-    public async Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, CancellationToken cancellationToken = default)
+    /// <remarks>
+    /// "Now" comes from the injected <see cref="TimeProvider"/>. Rows go in chunks of
+    /// <see cref="PurgeChunkSize"/> per monitor (both queries walk the primary-key index), so a
+    /// first purge of a large backlog is not one unbounded DELETE holding the write lock (#23).
+    /// </remarks>
+    public async Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, int maxEventsPerMonitor, CancellationToken cancellationToken = default)
     {
-        // If retention is zero or negative, nothing should be purged.
-        if (retentionPeriod <= TimeSpan.Zero)
+        var purgeByAge = retentionPeriod > TimeSpan.Zero;
+        var purgeByCount = maxEventsPerMonitor > 0;
+        if (!purgeByAge && !purgeByCount)
         {
             return 0;
         }
 
-        var cutoffTimestamp = DateTimeOffset.UtcNow - retentionPeriod;
-        var cutoffTicks = cutoffTimestamp.UtcTicks;
+        var cutoffTicks = (_timeProvider.GetUtcNow() - retentionPeriod).UtcTicks;
 
         // Create connection per operation
         using var connection = new SqliteConnection(_connectionString);
         await connection.OpenAsync(cancellationToken);
 
-        using var command = connection.CreateCommand();
-        command.CommandText = $"""
-            DELETE FROM {EventsTableName}
-            WHERE TimestampTicks < @CutoffTicks;
-        """;
-        command.Parameters.AddWithValue("@CutoffTicks", cutoffTicks);
+        var deleted = 0;
+        foreach (var monitorName in await ListMonitorNamesAsync(connection, cancellationToken))
+        {
+            if (purgeByAge)
+            {
+                deleted += await DeleteInChunksAsync(connection, $"""
+                    DELETE FROM {EventsTableName}
+                    WHERE rowid IN (
+                        SELECT rowid FROM {EventsTableName}
+                        WHERE MonitorName = @MonitorName AND TimestampTicks < @CutoffTicks
+                        ORDER BY TimestampTicks
+                        LIMIT @ChunkSize);
+                    """, monitorName, ("@CutoffTicks", cutoffTicks), cancellationToken);
+            }
+
+            if (purgeByCount)
+            {
+                deleted += await DeleteInChunksAsync(connection, $"""
+                    DELETE FROM {EventsTableName}
+                    WHERE rowid IN (
+                        SELECT rowid FROM {EventsTableName}
+                        WHERE MonitorName = @MonitorName
+                        ORDER BY TimestampTicks DESC
+                        LIMIT @ChunkSize OFFSET @MaxEvents);
+                    """, monitorName, ("@MaxEvents", maxEventsPerMonitor), cancellationToken);
+            }
+        }
+
+        if (deleted > 0)
+        {
+            await ReclaimSpaceAsync(connection, cancellationToken);
+        }
 
         // The caller (PurgeBackgroundService) logs the outcome with a real logger.
-        return await command.ExecuteNonQueryAsync(cancellationToken);
+        return deleted;
+    }
+
+    private static async Task<List<string>> ListMonitorNamesAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        var names = new List<string>();
+        using var command = connection.CreateCommand();
+        command.CommandText = $"SELECT DISTINCT MonitorName FROM {EventsTableName};";
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            names.Add(reader.GetString(0));
+        }
+
+        return names;
+    }
+
+    private static async Task<int> DeleteInChunksAsync(
+        SqliteConnection connection, string sql, string monitorName, (string Name, long Value) parameter, CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("@MonitorName", monitorName);
+        command.Parameters.AddWithValue("@ChunkSize", PurgeChunkSize);
+        command.Parameters.AddWithValue(parameter.Name, parameter.Value);
+
+        var total = 0;
+        int chunk;
+        do
+        {
+            chunk = await command.ExecuteNonQueryAsync(cancellationToken);
+            total += chunk;
+        } while (chunk == PurgeChunkSize);
+
+        return total;
+    }
+
+    /// <summary>
+    /// Gives deleted pages back to the file system. Without this the database never shrank:
+    /// tightening the retention reclaimed zero disk (#23).
+    /// </summary>
+    private static async Task ReclaimSpaceAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        // 0 = NONE, 1 = FULL, 2 = INCREMENTAL.
+        long autoVacuum;
+        using (var query = connection.CreateCommand())
+        {
+            query.CommandText = "PRAGMA auto_vacuum;";
+            autoVacuum = (long)(await query.ExecuteScalarAsync(cancellationToken))!;
+        }
+
+        using var command = connection.CreateCommand();
+        command.CommandText = autoVacuum switch
+        {
+            // Frees every page on the freelist and truncates the file. Cheap: no rewrite.
+            2 => "PRAGMA incremental_vacuum;",
+            // FULL already shrinks the file on every commit.
+            1 => "",
+            // Database created before InitializeAsync set auto_vacuum: switching away from NONE
+            // needs one full VACUUM (a rewrite). Later purges take the incremental path.
+            _ => "PRAGMA auto_vacuum=INCREMENTAL; VACUUM;",
+        };
+        if (command.CommandText.Length > 0)
+        {
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        // In WAL mode the truncation lives in the log until a checkpoint copies it into the main
+        // file; TRUNCATE also resets the log, which a VACUUM can leave as large as the database.
+        // A busy checkpoint (concurrent reader) is not an error: the next automatic one finishes it.
+        command.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
+        await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 namespace Deucalion.Tests.Api;
 
 [Collection(ProcessEnvironmentCollection.Name)]
-public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
+public sealed class ApiIntegrationTests : IAsyncLifetime
 {
     // Configuration file path is read during WebApplicationBuilder construction,
     // before WebApplicationFactory's ConfigureWebHost callbacks land — so we
@@ -70,7 +70,18 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
 
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async ValueTask DisposeAsync() => await _factory.DisposeAsync();
+    // Cleanup lives here, not in IDisposable.Dispose(): xunit.v3 calls only DisposeAsync() on a
+    // class that implements IAsyncLifetime, so the old Dispose() never ran -- the env vars
+    // outlived each test and every instance leaked its directory under %TEMP%.
+    public async ValueTask DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+
+        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, null);
+        Environment.SetEnvironmentVariable(StoragePathEnvVar, null);
+
+        TestPaths.DeleteWithRetry(_tempPath);
+    }
 
     [Fact]
     public async Task GetConfiguration_ReturnsConfiguredMetadata()
@@ -499,14 +510,6 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
                     entries.Add((logLevel, category, formatter(state, exception) + (exception is null ? "" : $" [{exception.GetType().Name}]")));
             }
         }
-    }
-
-    public void Dispose()
-    {
-        Environment.SetEnvironmentVariable(ConfigurationFileEnvVar, null);
-        Environment.SetEnvironmentVariable(StoragePathEnvVar, null);
-
-        TestPaths.DeleteWithRetry(_tempPath);
     }
 
     private sealed class TestApiFactory : WebApplicationFactory<Program>

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using Deucalion.Api.Services;
 using Deucalion.Storage;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.DependencyInjection;
@@ -202,6 +203,43 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Issue23_CorsPreflight_ForCheckIn_AllowsMethodAndSecretHeader()
+    {
+        // A cross-origin check-in carries a custom header, so the browser sends a preflight.
+        // Origin-only CORS emitted no Allow-Methods / Allow-Headers and the browser blocked it.
+        using var client = _factory.CreateClient();
+
+        var preflight = new HttpRequestMessage(HttpMethod.Options, "/api/monitors/checkin-main/checkin");
+        preflight.Headers.Add("Origin", "https://status.example.org");
+        preflight.Headers.Add("Access-Control-Request-Method", "POST");
+        preflight.Headers.Add("Access-Control-Request-Headers", "deucalion-checkin-secret");
+
+        using var response = await client.SendAsync(preflight, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
+        Assert.Contains("POST", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Methods")), StringComparison.Ordinal);
+        Assert.Contains("deucalion-checkin-secret", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Headers")), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Issue23_CorsHeaders_ArePresentOnUnhandledExceptionResponses()
+    {
+        // UseCors ran after UseExceptionHandler, so a 500 produced by the handler had no CORS
+        // headers and a browser could not even read the problem details. The factory appends a
+        // throwing middleware at the tail of the pipeline (see ThrowingTailFilter).
+        using var client = _factory.CreateClient();
+
+        var request = new HttpRequestMessage(HttpMethod.Get, ThrowingTailFilter.Path);
+        request.Headers.Add("Origin", "https://status.example.org");
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("*", Assert.Single(response.Headers.GetValues("Access-Control-Allow-Origin")));
     }
 
     [Fact]
@@ -438,6 +476,7 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseEnvironment("Development");
+            builder.ConfigureServices(services => services.AddTransient<IStartupFilter, ThrowingTailFilter>());
         }
     }
 
@@ -583,5 +622,24 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
         // exists under AOT and the source-generated context did not declare the type. This JIT
         // host cannot reproduce the failure, so pin the declaration directly.
         Assert.NotNull(Deucalion.Api.DeucalionJsonContext.Default.GetTypeInfo(typeof(Microsoft.AspNetCore.Mvc.ProblemDetails)));
+    }
+
+    /// <summary>
+    /// Appends a middleware after the application's own pipeline (so after routing: only
+    /// unmatched paths reach it) that throws for one path. It stands in for any unhandled
+    /// exception so the exception handler's response can be inspected end to end.
+    /// </summary>
+    private sealed class ThrowingTailFilter : IStartupFilter
+    {
+        public const string Path = "/throw-for-test";
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+        {
+            next(app);
+            app.Use((context, nextMiddleware) =>
+                context.Request.Path == Path
+                    ? throw new InvalidOperationException("Simulated unhandled exception.")
+                    : nextMiddleware(context));
+        };
     }
 }

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -206,6 +206,44 @@ public sealed class ApiIntegrationTests : IAsyncLifetime, IDisposable
     }
 
     [Fact]
+    public async Task Issue23_CheckInEndpoint_IsRateLimited_PerClient()
+    {
+        // Unauthenticated and reachable from anywhere: without a limit one client could hammer
+        // the endpoint (and brute-force a secret) without bound.
+        using var client = _factory.CreateClient();
+
+        for (var i = 0; i < Deucalion.Api.Application.CheckInRateLimitPerMinute; i++)
+        {
+            using var accepted = await client.PostAsync("/api/monitors/checkin-open/checkin", content: null, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, accepted.StatusCode);
+        }
+
+        using var rejected = await client.PostAsync("/api/monitors/checkin-open/checkin", content: null, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.TooManyRequests, rejected.StatusCode);
+
+        // Other endpoints are not subject to the check-in limit.
+        using var monitors = await client.GetAsync("/api/monitors", TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, monitors.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckInEndpoint_SecretOfDifferentLength_IsRejected()
+    {
+        // A prefix of the secret and a longer string must both fail (length is checked before
+        // the constant-time comparison).
+        using var client = _factory.CreateClient();
+
+        foreach (var wrong in new[] { "test-secre", "test-secret-and-more", "TEST-SECRET" })
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, "/api/monitors/checkin-main/checkin");
+            request.Headers.Add("deucalion-checkin-secret", wrong);
+
+            using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        }
+    }
+
+    [Fact]
     public async Task Issue23_CorsPreflight_ForCheckIn_AllowsMethodAndSecretHeader()
     {
         // A cross-origin check-in carries a custom header, so the browser sends a preflight.

--- a/src/cs/Deucalion.Tests/Api/DeucalionOptionsTests.cs
+++ b/src/cs/Deucalion.Tests/Api/DeucalionOptionsTests.cs
@@ -1,0 +1,56 @@
+using Deucalion.Api;
+using Deucalion.Api.Options;
+using Deucalion.Application.Configuration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Deucalion.Tests.Api;
+
+/// <summary>
+/// Regression for #23 (1): <c>DEUCALION__PURGEINTERVAL=00:00:00</c> used to bind silently and
+/// then kill the host from inside <c>PurgeBackgroundService</c> (<c>PeriodicTimer</c> rejects a
+/// non-positive period) with an opaque message. The options are now validated when bound.
+/// </summary>
+public class DeucalionOptionsTests
+{
+    [Theory]
+    [InlineData("PurgeInterval", "00:00:00")]
+    [InlineData("PurgeInterval", "-00:00:01")]
+    [InlineData("EventRetentionPeriod", "00:00:00")]
+    [InlineData("MaxEventsPerMonitor", "0")]
+    [InlineData("MaxEventsPerMonitor", "-1")]
+    public void Issue23_ConfigureApplicationBuilder_InvalidOption_FailsFastNamingTheOption(string option, string value)
+    {
+        var builder = WebApplication.CreateBuilder();
+
+        // In-memory values are added last, so they win over any Deucalion__* environment variable.
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [$"{DeucalionOptions.SectionName}:{option}"] = value,
+        });
+
+        var exception = Assert.Throws<ConfigurationErrorException>(() => builder.ConfigureApplicationBuilder());
+
+        Assert.Contains(option, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(value, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_DefaultsArePositive()
+    {
+        new DeucalionOptions().Validate();
+    }
+
+    [Theory]
+    [InlineData("00:00:00")]
+    [InlineData("-01:00:00")]
+    public void Validate_NonPositivePurgeInterval_Throws(string purgeInterval)
+    {
+        var options = new DeucalionOptions { PurgeInterval = TimeSpan.Parse(purgeInterval) };
+
+        var exception = Assert.Throws<ConfigurationErrorException>(options.Validate);
+
+        Assert.Contains("Deucalion:PurgeInterval", exception.Message, StringComparison.Ordinal);
+    }
+}

--- a/src/cs/Deucalion.Tests/Api/PurgeBackgroundServiceTests.cs
+++ b/src/cs/Deucalion.Tests/Api/PurgeBackgroundServiceTests.cs
@@ -19,17 +19,19 @@ public class PurgeBackgroundServiceTests
         private int _callCount;
 
         public List<TimeSpan> Retentions { get; } = [];
+        public List<int> MaxEventsPerMonitor { get; } = [];
         public Task FirstCall => _firstCall.Task;
         public int CallCount => Volatile.Read(ref _callCount);
 
         /// <summary>Set to have the next purge throw, to check the loop survives it.</summary>
         public bool ThrowOnPurge { get; set; }
 
-        public Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, CancellationToken cancellationToken = default)
+        public Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, int maxEventsPerMonitor, CancellationToken cancellationToken = default)
         {
             lock (Retentions)
             {
                 Retentions.Add(retentionPeriod);
+                MaxEventsPerMonitor.Add(maxEventsPerMonitor);
             }
 
             Interlocked.Increment(ref _callCount);
@@ -48,13 +50,15 @@ public class PurgeBackgroundServiceTests
 
     private static (PurgeBackgroundService Service, RecordingStorage Storage, FakeTimeProvider Time) Build(
         TimeSpan? purgeInterval = null,
-        TimeSpan? retention = null)
+        TimeSpan? retention = null,
+        int maxEventsPerMonitor = 100_000)
     {
         var storage = new RecordingStorage();
         var options = new DeucalionOptions
         {
             PurgeInterval = purgeInterval ?? TimeSpan.FromHours(24),
             EventRetentionPeriod = retention ?? TimeSpan.FromDays(30),
+            MaxEventsPerMonitor = maxEventsPerMonitor,
         };
         var time = new FakeTimeProvider();
         var service = new PurgeBackgroundService(storage, options, time, NullLogger<PurgeBackgroundService>.Instance);
@@ -91,13 +95,14 @@ public class PurgeBackgroundServiceTests
     public async Task PurgesOnceImmediatelyAtStartup()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        var (service, storage, _) = Build(retention: TimeSpan.FromDays(7));
+        var (service, storage, _) = Build(retention: TimeSpan.FromDays(7), maxEventsPerMonitor: 1234);
 
         await service.StartAsync(cancellationToken);
         await storage.FirstCall.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken);
 
         Assert.Equal(1, storage.CallCount);
         Assert.Equal(TimeSpan.FromDays(7), storage.Retentions[0]);
+        Assert.Equal(1234, storage.MaxEventsPerMonitor[0]); // The row cap reaches the storage (#23).
 
         await service.StopAsync(cancellationToken);
     }

--- a/src/cs/Deucalion.Tests/Configuration/ConfigurationTests.cs
+++ b/src/cs/Deucalion.Tests/Configuration/ConfigurationTests.cs
@@ -164,6 +164,46 @@ public class ConfigurationTests
     }
 
     [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    [InlineData(70000)]
+    public void Issue23_TcpMonitor_PortOutOfRange_Throws(int port)
+    {
+        // [Required] never fires on a non-nullable int, so these used to load fine and fail on
+        // every probe with ArgumentOutOfRangeException.
+        var configurationContent = $@"
+            monitors:
+              mtcp:
+                !tcp
+                host: 192.168.1.2
+                port: {port}
+        ";
+
+        var exception = CatchConfigurationException(configurationContent);
+        Assert.Contains("mtcp", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Port", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("65535", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(65535)]
+    public void TcpMonitor_PortAtRangeBounds_IsAccepted(int port)
+    {
+        var configurationContent = $@"
+            monitors:
+              mtcp:
+                !tcp
+                host: 192.168.1.2
+                port: {port}
+        ";
+
+        var tcpMonitor = Assert.IsType<TcpMonitorConfiguration>(ReadSingleMonitorFromConfiguration(configurationContent));
+        Assert.Equal(port, tcpMonitor.Port);
+    }
+
+    [Theory]
     [InlineData("events")]
     [InlineData("Events")]
     [InlineData("EVENTS")]

--- a/src/cs/Deucalion.Tests/Configuration/ConfigurationTests.cs
+++ b/src/cs/Deucalion.Tests/Configuration/ConfigurationTests.cs
@@ -163,6 +163,38 @@ public class ConfigurationTests
         Assert.Equal(65000, tcpMonitor.Port);
     }
 
+    [Theory]
+    [InlineData("events")]
+    [InlineData("Events")]
+    [InlineData("EVENTS")]
+    public void Issue23_ReservedMonitorName_Throws(string monitorName)
+    {
+        // '/api/monitors/events' is the SSE stream; a monitor with that name could never be
+        // fetched individually. Routing is case-insensitive, so the check is too.
+        var configurationContent = $@"
+            monitors:
+              {monitorName}:
+                !ping
+                host: 192.168.1.1
+        ";
+
+        var exception = CatchConfigurationException(configurationContent);
+        Assert.Equal(string.Format(ApplicationConfiguration.Messages.ConfigurationReservedMonitorName, monitorName, "events"), exception.Message);
+    }
+
+    [Fact]
+    public void MonitorNameContainingReservedWord_IsAccepted()
+    {
+        const string ConfigurationContent = @"
+            monitors:
+              events-api:
+                !ping
+                host: 192.168.1.1
+        ";
+
+        Assert.Equal("events-api", ReadSingleMonitorFromConfiguration(ConfigurationContent).Name);
+    }
+
     [Fact]
     public void CheckInMonitor_CanDeserialize()
     {

--- a/src/cs/Deucalion.Tests/Storage/SqliteStoragePurgeTests.cs
+++ b/src/cs/Deucalion.Tests/Storage/SqliteStoragePurgeTests.cs
@@ -1,136 +1,245 @@
 using Deucalion.Storage;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace Deucalion.Tests.Storage;
 
 public class SqliteStoragePurgeTests : SqliteStorageTestBase
 {
+    private readonly FakeTimeProvider _time;
+
+    public SqliteStoragePurgeTests() : this(new FakeTimeProvider()) { }
+
+    private SqliteStoragePurgeTests(FakeTimeProvider time) : base(time)
+    {
+        _time = time;
+    }
+
+    private DateTimeOffset Now => _time.GetUtcNow();
+
+    private static IEnumerable<StoredEvent> EventsEndingAt(DateTimeOffset newest, int count, TimeSpan step, string? responseText = null) =>
+        Enumerable.Range(0, count).Select(i => new StoredEvent(newest - step * i, MonitorState.Up, TimeSpan.FromMilliseconds(i), responseText));
+
     [Fact]
     public async Task PurgeOldEventsAsync_RemovesOldEventsAndKeepsRecentOnes()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        // Arrange
         var monitorName = "purge-test-monitor";
-        var now = DateTimeOffset.UtcNow;
         var retentionPeriod = TimeSpan.FromDays(7);
-        var cutoff = now - retentionPeriod;
+        var cutoff = Now - retentionPeriod;
 
         var eventsToSave = new List<StoredEvent>
         {
             // Should be kept
             new(cutoff.AddHours(1), MonitorState.Up, TimeSpan.FromMilliseconds(100), "Recent 1"),
-            new(now, MonitorState.Up, TimeSpan.FromMilliseconds(110), "Recent 2"),
+            new(Now, MonitorState.Up, TimeSpan.FromMilliseconds(110), "Recent 2"),
 
             // Should be purged
             new(cutoff.AddHours(-1), MonitorState.Down, null, "Old 1"),
             new(cutoff.AddDays(-1), MonitorState.Up, TimeSpan.FromMilliseconds(120), "Old 2"),
-            new(now.AddDays(-30), MonitorState.Up, TimeSpan.FromMilliseconds(130), "Very Old 3")
+            new(Now.AddDays(-30), MonitorState.Up, TimeSpan.FromMilliseconds(130), "Very Old 3")
         };
 
-        // Save events in chronological order
         foreach (var ev in eventsToSave.OrderBy(e => e.At))
         {
             await Storage.SaveEventAsync(monitorName, ev, cancellationToken);
         }
 
-        // Pre-assertion: Ensure all events are saved initially
-        var initialEvents = (await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken)).ToList();
-        Assert.Equal(eventsToSave.Count, initialEvents.Count);
+        Assert.Equal(eventsToSave.Count, await CountEventsAsync(monitorName, cancellationToken));
 
-        // Act
         var deletedCount = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
 
-        // Assert
-        Assert.Equal(3, deletedCount); // Expecting 3 old events to be deleted
+        Assert.Equal(3, deletedCount);
 
         var remainingEvents = (await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken)).ToList();
-        Assert.Equal(2, remainingEvents.Count); // Expecting 2 recent events to remain
-
-        // Verify the correct events remain (newest first)
-        Assert.Contains(remainingEvents, e => e.ResponseText == "Recent 2");
-        Assert.Contains(remainingEvents, e => e.ResponseText == "Recent 1");
-        Assert.DoesNotContain(remainingEvents, e => e.ResponseText == "Old 1");
-        Assert.DoesNotContain(remainingEvents, e => e.ResponseText == "Old 2");
-        Assert.DoesNotContain(remainingEvents, e => e.ResponseText == "Very Old 3");
-
-        // Verify timestamps are correct relative to cutoff
+        Assert.Equal(["Recent 2", "Recent 1"], remainingEvents.Select(e => e.ResponseText));
         Assert.All(remainingEvents, e => Assert.True(e.At >= cutoff));
     }
 
     [Fact]
-    public async Task PurgeOldEventsAsync_ZeroRetention_DoesNotPurge()
+    public async Task Issue23_PurgeOldEventsAsync_UsesTheInjectedClock()
+    {
+        // The cutoff used to come from DateTimeOffset.UtcNow regardless of the TimeProvider the
+        // host injects, so the retention could not be driven by a fake clock.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var monitorName = "purge-clock";
+        var retentionPeriod = TimeSpan.FromDays(7);
+
+        await Storage.SaveEventAsync(monitorName, new(Now.AddDays(-8), MonitorState.Up, null, "8 days old"), cancellationToken);
+        await Storage.SaveEventAsync(monitorName, new(Now.AddDays(-6), MonitorState.Up, null, "6 days old"), cancellationToken);
+
+        Assert.Equal(1, await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken));
+        Assert.Equal("6 days old", Assert.Single(await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken)).ResponseText);
+
+        // Two virtual days later the remaining event is 8 days old and goes too.
+        _time.Advance(TimeSpan.FromDays(2));
+
+        Assert.Equal(1, await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken));
+        Assert.Empty(await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken));
+    }
+
+    [Fact]
+    public async Task PurgeOldEventsAsync_ZeroRetentionAndNoCap_DoesNotPurge()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        // Arrange
         var monitorName = "purge-zero-retention";
-        var now = DateTimeOffset.UtcNow;
         var eventsToSave = new List<StoredEvent>
         {
-            new(now.AddMinutes(-10), MonitorState.Up, TimeSpan.FromMilliseconds(100), "Event 1"),
-            new(now.AddMinutes(-5), MonitorState.Down, null, "Event 2"),
+            new(Now.AddMinutes(-10), MonitorState.Up, TimeSpan.FromMilliseconds(100), "Event 1"),
+            new(Now.AddMinutes(-5), MonitorState.Down, null, "Event 2"),
         };
         foreach (var ev in eventsToSave) await Storage.SaveEventAsync(monitorName, ev, cancellationToken);
 
-        // Act
-        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.Zero, cancellationToken);
+        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.Zero, maxEventsPerMonitor: 0, cancellationToken);
 
-        // Assert
-        Assert.Equal(0, deletedCount); // Nothing should be deleted with zero retention
-        var remainingEvents = (await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken)).ToList();
-        Assert.Equal(eventsToSave.Count, remainingEvents.Count); // All events should remain
+        Assert.Equal(0, deletedCount);
+        Assert.Equal(eventsToSave.Count, await CountEventsAsync(monitorName, cancellationToken));
     }
 
     [Fact]
     public async Task PurgeOldEventsAsync_AllEventsOld_PurgesAll()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        // Arrange
         var monitorName = "purge-all-old";
-        var now = DateTimeOffset.UtcNow;
-        var retentionPeriod = TimeSpan.FromHours(1); // Purge anything older than 1 hour
+        var retentionPeriod = TimeSpan.FromHours(1);
         var eventsToSave = new List<StoredEvent>
         {
-            new(now.AddHours(-2), MonitorState.Up, TimeSpan.FromMilliseconds(100), "Old Event 1"),
-            new(now.AddHours(-3), MonitorState.Down, null, "Old Event 2"),
+            new(Now.AddHours(-2), MonitorState.Up, TimeSpan.FromMilliseconds(100), "Old Event 1"),
+            new(Now.AddHours(-3), MonitorState.Down, null, "Old Event 2"),
         };
         foreach (var ev in eventsToSave) await Storage.SaveEventAsync(monitorName, ev, cancellationToken);
 
-        // Act
         var deletedCount = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
 
-        // Assert
-        Assert.Equal(eventsToSave.Count, deletedCount); // All events should be deleted
-        var remainingEvents = (await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken)).ToList();
-        Assert.Empty(remainingEvents); // No events should remain
+        Assert.Equal(eventsToSave.Count, deletedCount);
+        Assert.Empty(await Storage.GetLastEventsAsync(monitorName, 10, cancellationToken));
     }
 
     [Fact]
     public async Task PurgeOldEventsAsync_NoEventsOrAllNew_PurgesNone()
     {
         var cancellationToken = TestContext.Current.CancellationToken;
-        // Arrange
-        // Removed unused variable: var monitorNameNoEvents = "purge-no-events";
-        var monitorNameAllNew = "purge-all-new";
-        var now = DateTimeOffset.UtcNow;
-        var retentionPeriod = TimeSpan.FromDays(1); // Purge anything older than 1 day
+        var monitorName = "purge-all-new";
+        var retentionPeriod = TimeSpan.FromDays(1);
 
-        // Setup monitor with all new events
+        var deletedCountNoEvents = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
+
         var newEvents = new List<StoredEvent>
         {
-            new(now.AddHours(-1), MonitorState.Up, TimeSpan.FromMilliseconds(100), "New Event 1"),
-            new(now.AddHours(-2), MonitorState.Up, TimeSpan.FromMilliseconds(110), "New Event 2"),
+            new(Now.AddHours(-1), MonitorState.Up, TimeSpan.FromMilliseconds(100), "New Event 1"),
+            new(Now.AddHours(-2), MonitorState.Up, TimeSpan.FromMilliseconds(110), "New Event 2"),
         };
-        foreach (var ev in newEvents) await Storage.SaveEventAsync(monitorNameAllNew, ev, cancellationToken);
+        foreach (var ev in newEvents) await Storage.SaveEventAsync(monitorName, ev, cancellationToken);
 
-        // Act
-        var deletedCountNoEvents = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
         var deletedCountAllNew = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
 
-        // Assert
-        Assert.Equal(0, deletedCountNoEvents); // No events existed, so 0 deleted
-        Assert.Equal(0, deletedCountAllNew);   // All events were newer than retention, so 0 deleted
+        Assert.Equal(0, deletedCountNoEvents);
+        Assert.Equal(0, deletedCountAllNew);
+        Assert.Equal(newEvents.Count, await CountEventsAsync(monitorName, cancellationToken));
+    }
 
-        var remainingEventsAllNew = (await Storage.GetLastEventsAsync(monitorNameAllNew, 10, cancellationToken)).ToList();
-        Assert.Equal(newEvents.Count, remainingEventsAllNew.Count); // All new events should remain
+    [Fact]
+    public async Task Issue23_PurgeOldEventsAsync_CapsTheEventsKeptPerMonitor()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var step = TimeSpan.FromSeconds(3);
+
+        await BulkInsertAsync("busy", EventsEndingAt(Now, 150, step), cancellationToken);
+        await BulkInsertAsync("quiet", EventsEndingAt(Now, 50, step), cancellationToken);
+
+        // Retention disabled: only the cap can delete here.
+        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.Zero, maxEventsPerMonitor: 100, cancellationToken);
+
+        Assert.Equal(50, deletedCount);
+        Assert.Equal(100, await CountEventsAsync("busy", cancellationToken));
+        Assert.Equal(50, await CountEventsAsync("quiet", cancellationToken));
+
+        // The newest 100 survive, not an arbitrary 100.
+        var busy = (await Storage.GetLastEventsAsync("busy", 1000, cancellationToken)).ToList();
+        Assert.Equal(Now, busy[0].At);
+        Assert.Equal(Now - step * 99, busy[^1].At);
+    }
+
+    [Fact]
+    public async Task Issue23_PurgeOldEventsAsync_AgeAndCap_AreBothApplied()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var step = TimeSpan.FromDays(1);
+
+        // 20 daily events: 10 within a 10-day retention, of which the cap keeps 5.
+        await BulkInsertAsync("m", EventsEndingAt(Now, 20, step), cancellationToken);
+
+        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.FromDays(10), maxEventsPerMonitor: 5, cancellationToken);
+
+        Assert.Equal(15, deletedCount);
+        Assert.Equal(5, await CountEventsAsync("m", cancellationToken));
+    }
+
+    [Fact]
+    public async Task Issue23_PurgeOldEventsAsync_DeletesInChunks_AndKeepsTheNewestRows()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var step = TimeSpan.FromSeconds(1);
+        const int keep = 3_000;
+        var total = 2 * SqliteStorage.PurgeChunkSize + 5_000; // > 2 chunks to delete, plus a partial one
+
+        await BulkInsertAsync("bulk", EventsEndingAt(Now, total, step), cancellationToken);
+
+        // Cutoff falls right between the newest 'keep' rows and the rest.
+        var retentionPeriod = step * (keep - 1) + TimeSpan.FromTicks(1);
+        var deletedCount = await Storage.PurgeOldEventsAsync(retentionPeriod, cancellationToken);
+
+        Assert.Equal(total - keep, deletedCount);
+        Assert.Equal(keep, await CountEventsAsync("bulk", cancellationToken));
+
+        var remaining = (await Storage.GetLastEventsAsync("bulk", total, cancellationToken)).ToList();
+        Assert.Equal(Now, remaining[0].At);
+        Assert.Equal(Now - step * (keep - 1), remaining[^1].At);
+    }
+
+    [Fact]
+    public async Task Issue23_PurgeOldEventsAsync_ReturnsDiskToTheFileSystem()
+    {
+        // The purge never ran VACUUM (nor was auto_vacuum set), so the file never shrank: a user
+        // tightening the retention saw zero disk reclaimed.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var padding = new string('x', 512);
+
+        await BulkInsertAsync("fat", EventsEndingAt(Now, 20_000, TimeSpan.FromSeconds(1), padding), cancellationToken);
+        var sizeBefore = await GetDatabaseSizeAsync(cancellationToken);
+        Assert.True(sizeBefore > 8 * 1024 * 1024, $"Expected a database of several MB, got {sizeBefore} bytes.");
+
+        Assert.Equal(2L, await ExecuteScalarAsync<long>("PRAGMA auto_vacuum;", cancellationToken)); // INCREMENTAL, set by InitializeAsync
+
+        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.Zero, maxEventsPerMonitor: 100, cancellationToken);
+
+        // Measured straight after the purge, without any help from the test: the purge itself
+        // must checkpoint, or the shrink would sit in the WAL until some later checkpoint.
+        var sizeAfter = new FileInfo(DbFilePath).Length;
+        var walAfter = new FileInfo(DbFilePath + "-wal") is { Exists: true } wal ? wal.Length : 0;
+
+        Assert.Equal(19_900, deletedCount);
+        Assert.True(sizeAfter < sizeBefore / 10, $"Expected the file to shrink by an order of magnitude, but it went from {sizeBefore} to {sizeAfter} bytes.");
+        Assert.Equal(0, walAfter);
+    }
+
+    [Fact]
+    public async Task Issue23_PurgeOldEventsAsync_ConvertsADatabaseCreatedWithoutAutoVacuum()
+    {
+        // Databases from before this fix have auto_vacuum=NONE, which incremental_vacuum cannot
+        // shrink; the first purge that deletes rows must fall back to a full VACUUM and convert.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await ExecuteScalarAsync<object?>("PRAGMA auto_vacuum=NONE; VACUUM;", cancellationToken);
+        Assert.Equal(0L, await ExecuteScalarAsync<long>("PRAGMA auto_vacuum;", cancellationToken));
+
+        await BulkInsertAsync("legacy", EventsEndingAt(Now, 20_000, TimeSpan.FromSeconds(1), new string('x', 512)), cancellationToken);
+        var sizeBefore = await GetDatabaseSizeAsync(cancellationToken);
+
+        var deletedCount = await Storage.PurgeOldEventsAsync(TimeSpan.Zero, maxEventsPerMonitor: 100, cancellationToken);
+        var sizeAfter = await GetDatabaseSizeAsync(cancellationToken);
+
+        Assert.Equal(19_900, deletedCount);
+        Assert.True(sizeAfter < sizeBefore / 10, $"Expected the file to shrink by an order of magnitude, but it went from {sizeBefore} to {sizeAfter} bytes.");
+        Assert.Equal(2L, await ExecuteScalarAsync<long>("PRAGMA auto_vacuum;", cancellationToken));
     }
 }

--- a/src/cs/Deucalion.Tests/Storage/SqliteStorageTestBase.cs
+++ b/src/cs/Deucalion.Tests/Storage/SqliteStorageTestBase.cs
@@ -1,4 +1,5 @@
 using Deucalion.Storage;
+using Microsoft.Data.Sqlite;
 using Xunit;
 
 namespace Deucalion.Tests.Storage;
@@ -9,14 +10,19 @@ public abstract class SqliteStorageTestBase : IAsyncLifetime, IDisposable
     protected readonly string DbFilePath;
     protected readonly SqliteStorage Storage;
 
-    protected SqliteStorageTestBase()
+    /// <param name="timeProvider">The storage's clock; defaults to the system clock.</param>
+    protected SqliteStorageTestBase(TimeProvider? timeProvider = null)
     {
         // A unique directory per test instance, so tests never share a database.
         StoragePath = Path.Combine(Path.GetTempPath(), $"Deucalion.Tests.SqliteStorage_{Guid.NewGuid()}");
         Directory.CreateDirectory(StoragePath);
         DbFilePath = Path.Combine(StoragePath, "deucalion.sqlite.db");
-        Storage = new SqliteStorage(StoragePath);
+        Storage = new SqliteStorage(StoragePath, timeProvider);
     }
+
+    // Unpooled: a pooled connection keeps reporting the auto_vacuum mode it first saw, which
+    // would make assertions about a mode changed through another connection lie.
+    private string HelperConnectionString => $"Data Source={DbFilePath};Pooling=False";
 
     public ValueTask InitializeAsync() => new(Storage.InitializeAsync(TestContext.Current.CancellationToken));
 
@@ -31,5 +37,73 @@ public abstract class SqliteStorageTestBase : IAsyncLifetime, IDisposable
         TestPaths.DeleteWithRetry(StoragePath);
 
         GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Inserts many events in one transaction. SaveEventAsync opens a connection and commits per
+    /// row, which is what the engine needs but far too slow for tests that want tens of
+    /// thousands of rows.
+    /// </summary>
+    protected async Task BulkInsertAsync(string monitorName, IEnumerable<StoredEvent> events, CancellationToken cancellationToken)
+    {
+        using var connection = new SqliteConnection(HelperConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        using var transaction = connection.BeginTransaction();
+
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO Events (MonitorName, TimestampTicks, State, ResponseTimeTicks, ResponseText)
+            VALUES (@MonitorName, @TimestampTicks, @State, @ResponseTimeTicks, @ResponseText);
+            """;
+        var timestamp = command.Parameters.Add("@TimestampTicks", SqliteType.Integer);
+        var state = command.Parameters.Add("@State", SqliteType.Integer);
+        var responseTime = command.Parameters.Add("@ResponseTimeTicks", SqliteType.Integer);
+        var responseText = command.Parameters.Add("@ResponseText", SqliteType.Text);
+        command.Parameters.AddWithValue("@MonitorName", monitorName);
+
+        foreach (var e in events)
+        {
+            timestamp.Value = e.At.UtcTicks;
+            state.Value = (int)e.State;
+            responseTime.Value = e.ResponseTime?.Ticks ?? (object)DBNull.Value;
+            responseText.Value = e.ResponseText ?? (object)DBNull.Value;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+    }
+
+    protected async Task<long> CountEventsAsync(string monitorName, CancellationToken cancellationToken)
+    {
+        using var connection = new SqliteConnection(HelperConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM Events WHERE MonitorName = @MonitorName;";
+        command.Parameters.AddWithValue("@MonitorName", monitorName);
+        return (long)(await command.ExecuteScalarAsync(cancellationToken))!;
+    }
+
+    /// <summary>
+    /// Size of the database on disk. Checkpoints first, so what is still in the WAL is folded into
+    /// the main file and the number reflects what the file system will keep.
+    /// </summary>
+    protected async Task<long> GetDatabaseSizeAsync(CancellationToken cancellationToken)
+    {
+        using var connection = new SqliteConnection(HelperConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA wal_checkpoint(TRUNCATE);";
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return new FileInfo(DbFilePath).Length;
+    }
+
+    protected async Task<T> ExecuteScalarAsync<T>(string sql, CancellationToken cancellationToken)
+    {
+        using var connection = new SqliteConnection(HelperConnectionString);
+        await connection.OpenAsync(cancellationToken);
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return (T)(await command.ExecuteScalarAsync(cancellationToken))!;
     }
 }

--- a/src/cs/Deucalion.Tests/Storage/SqliteStorageTestBase.cs
+++ b/src/cs/Deucalion.Tests/Storage/SqliteStorageTestBase.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Deucalion.Tests.Storage;
 
-public abstract class SqliteStorageTestBase : IAsyncLifetime, IDisposable
+public abstract class SqliteStorageTestBase : IAsyncLifetime
 {
     protected readonly string StoragePath;
     protected readonly string DbFilePath;
@@ -26,9 +26,10 @@ public abstract class SqliteStorageTestBase : IAsyncLifetime, IDisposable
 
     public ValueTask InitializeAsync() => new(Storage.InitializeAsync(TestContext.Current.CancellationToken));
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
-
-    public void Dispose()
+    // Cleanup lives here, not in IDisposable.Dispose(): xunit.v3 calls only DisposeAsync() on a
+    // class that implements IAsyncLifetime, so a Dispose() silently never ran and every test
+    // instance leaked its directory under %TEMP%.
+    public ValueTask DisposeAsync()
     {
         // Dispose the storage first -- it clears the connection pool, which releases the
         // database file handle before we try to delete the directory.
@@ -36,7 +37,7 @@ public abstract class SqliteStorageTestBase : IAsyncLifetime, IDisposable
 
         TestPaths.DeleteWithRetry(StoragePath);
 
-        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #23

Six small, independent defects, one commit each, plus a test-lifecycle fix found on the way. Every fix ships with a regression test named after the issue that was verified to fail before the change and pass after.

## 1. Options validation (`de32bd7`)
`DEUCALION__PURGEINTERVAL=00:00:00` bound silently, then `PeriodicTimer` threw inside `PurgeBackgroundService` and `StopHost` took the host down. `DeucalionOptions.Validate()` now runs right after binding in `ConfigureApplicationBuilder` (positive `PurgeInterval`, `EventRetentionPeriod`, `MaxEventsPerMonitor`) and throws `ConfigurationErrorException` naming the option -- `Program` already reports that as `Configuration error: ...`, exit 1.
- `DeucalionOptionsTests.Issue23_ConfigureApplicationBuilder_InvalidOption_FailsFastNamingTheOption` (5 cases) builds the host with an in-memory invalid value and asserts the option name and value are in the message. Before the fix the builder went on and failed with `Configuration file 'deucalion.yaml' not found` instead.

## 2. CORS (`15f3bbb`)
`AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader()`, and `UseCors` moved before `UseExceptionHandler`.
- `Issue23_CorsPreflight_ForCheckIn_AllowsMethodAndSecretHeader`: `OPTIONS /api/monitors/x/checkin` with `Origin` + `Access-Control-Request-Method: POST` + `Access-Control-Request-Headers: deucalion-checkin-secret` returns 204 with `Allow-Origin: *`, `Allow-Methods` containing `POST`, `Allow-Headers` containing the secret header. Failed before (no allow headers).
- `Issue23_CorsHeaders_ArePresentOnUnhandledExceptionResponses`: a startup filter appends a throwing middleware; the 500 the exception handler produces carries `Allow-Origin`. Note: this one also passed with the old ordering under `TestServer` (CORS applies simple-request headers via `OnStarting`), so it guards the ordering rather than proving the old one broke.

## 3. Secret comparison + rate limiting (`8791d9b`)
`CryptographicOperations.FixedTimeEquals` over UTF-8 bytes after a length check. `AddRateLimiter` with a fixed-window policy `checkin` (60/min, partitioned by `RemoteIpAddress`, `QueueLimit = 0`, 429 on rejection), applied only via `.RequireRateLimiting("checkin")` on the check-in endpoint; `UseRateLimiter` sits after `UseCors`. No reflection; the Release build (trim/AOT analyzers on) is warning-free -- the Docker leg does the real AOT publish.
- `Issue23_CheckInEndpoint_IsRateLimited_PerClient`: 60 check-ins are 200, the 61st is 429, `GET /api/monitors` still 200. Fails without `RequireRateLimiting`.
- `CheckInEndpoint_SecretOfDifferentLength_IsRejected`: prefix, longer and case-different secrets are 401.

## 4. Route shadowing (`1d6db99`)
`ApplicationConfiguration` rejects the monitor name `events` (case-insensitive, like routing) with `Monitor 'events': the name is reserved (it would clash with the '/api/monitors/events' route)`. README's *Monitors Section* documents it.
- `Issue23_ReservedMonitorName_Throws` (`events`/`Events`/`EVENTS`), `MonitorNameContainingReservedWord_IsAccepted` (`events-api`).

## 5. Purge: chunks, row cap, VACUUM, TimeProvider (`73a0ee9`)
`IStorage.PurgeOldEventsAsync(retention, maxEventsPerMonitor, ct)`; the old two-argument form stays on `SqliteStorage` (no cap). Per monitor, in chunks of `PurgeChunkSize = 10_000` walking the primary-key index: `DELETE ... WHERE rowid IN (SELECT rowid ... LIMIT 10000)` for the age cutoff, and `... ORDER BY TimestampTicks DESC LIMIT 10000 OFFSET @MaxEvents` for the cap. Each chunk is its own transaction, so the write lock is released between chunks. After a purge that deleted rows: `PRAGMA incremental_vacuum` (InitializeAsync now sets `auto_vacuum=INCREMENTAL` before creating tables; a database from before this is detected via `PRAGMA auto_vacuum` and converted once with `PRAGMA auto_vacuum=INCREMENTAL; VACUUM`), then `PRAGMA wal_checkpoint(TRUNCATE)` so the shrink reaches the main file immediately. The cutoff comes from the injected `TimeProvider` (the host registers `TimeProvider.System`; `SqliteStorage` takes it as a constructor argument). New `DeucalionOptions.MaxEventsPerMonitor` (default 100,000), documented in a new README *Server options* table with all `DEUCALION__*` options.
- `SqliteStoragePurgeTests` now drive a `FakeTimeProvider`: `Issue23_PurgeOldEventsAsync_UsesTheInjectedClock` (advancing virtual time purges more), `..._CapsTheEventsKeptPerMonitor` (150/50 rows, cap 100 -> 50 deleted, newest 100 kept), `..._AgeAndCap_AreBothApplied`, `..._DeletesInChunks_AndKeepsTheNewestRows` (25,000 rows, 22,000 deleted across 3 chunks, the newest 3,000 remain with exact timestamps), `..._ReturnsDiskToTheFileSystem` (20,000 padded rows, >8 MB; after the purge the main file is <1/10 of that and the WAL is 0 bytes, measured without any help from the test), `..._ConvertsADatabaseCreatedWithoutAutoVacuum` (`auto_vacuum=NONE` database ends at 2 and shrinks). With the reclaim step and `TimeProvider` removed, 7 of the 10 purge tests fail.
- `PurgeBackgroundServiceTests.PurgesOnceImmediatelyAtStartup` asserts the cap reaches the storage.

## 6. TCP port range (`efc3b25`)
`[Range(1, 65535)]` on `TcpMonitorConfiguration.Port` (`[Required]` is a no-op on `int`).
- `Issue23_TcpMonitor_PortOutOfRange_Throws` (0, -1, 65536, 70000) asserts the message names `mtcp`, `Port` and `65535`; `TcpMonitor_PortAtRangeBounds_IsAccepted` (1, 65535).

## Bonus: test cleanup never ran (`1732fb1`)
xunit.v3 only calls `DisposeAsync()` on a class implementing `IAsyncLifetime`; `ApiIntegrationTests` and `SqliteStorageTestBase` cleaned up in `Dispose()`, which never ran. Cleanup moved to `DisposeAsync()`, `IDisposable` dropped. Evidence with `TEMP` redirected to an empty directory: the API + purge classes left 22 `Deucalion.Tests.*` directories before, 0 after (and the full suite leaves 0).

## Local verification
`dotnet build -c Release`: 0 warnings. `dotnet test -c Release -- --minimum-expected-tests 101`: 239 total, 231 passed, 8 skipped (network-gated), 0 failed. Rebased on `origin/master` (`8292afe`), no merge commits.
