### PR TITLE
test(e2e): Windows-safe per-run storage cleanup (follow-up to #45)

### DIFF
--- a/src/ts/deucalion-ui/playwright.config.ts
+++ b/src/ts/deucalion-ui/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
+// One storage directory per run; see tests/e2e/global-teardown.ts for why.
+const STORAGE_RUN_ID = Date.now().toString();
+process.env.E2E_STORAGE_RUN_ID = STORAGE_RUN_ID;
+
 const PORT = 5173;
 const BASE_URL = `http://localhost:${PORT.toString()}`;
 
@@ -43,7 +47,7 @@ export default defineConfig({
         "dotnet run --project ../../cs/Deucalion.Api -c Release --no-build --no-launch-profile --urls http://localhost:5000",
       env: {
         ASPNETCORE_ENVIRONMENT: "Development",
-        DEUCALION__STORAGEPATH: "./.e2e-storage",
+        DEUCALION__STORAGEPATH: `./.e2e-storage/${STORAGE_RUN_ID}`,
       },
       url: "http://localhost:5000/api/configuration",
       reuseExistingServer: !process.env.CI,

--- a/src/ts/deucalion-ui/tests/e2e/global-teardown.ts
+++ b/src/ts/deucalion-ui/tests/e2e/global-teardown.ts
@@ -1,11 +1,32 @@
-import { rm } from "node:fs/promises";
+import { readdir, rm } from "node:fs/promises";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-// playwright.config.ts points the backend at ./.e2e-storage, which `dotnet run`
-// resolves against the project directory. The SQLite database (and its WAL)
-// would otherwise accumulate across runs; nothing else cleans it up.
-const storageDir = fileURLToPath(new URL("../../../../cs/Deucalion.Api/.e2e-storage", import.meta.url));
+// playwright.config.ts points the backend at ./.e2e-storage/<run id>, which
+// `dotnet run` resolves against the project directory. Each run gets its own
+// subdirectory, and teardown deletes every *other* run's directory: on Windows
+// the backend is still alive (and holding the SQLite file) while teardown
+// runs, so the current run's directory cannot be removed here -- the next run
+// takes care of it. Without any of this the databases accumulated forever.
+const storageRoot = fileURLToPath(new URL("../../../../cs/Deucalion.Api/.e2e-storage", import.meta.url));
 
 export default async (): Promise<void> => {
-  await rm(storageDir, { recursive: true, force: true });
+  const current = process.env.E2E_STORAGE_RUN_ID;
+  let entries: string[];
+  try {
+    entries = await readdir(storageRoot);
+  } catch {
+    return; // Nothing to clean.
+  }
+
+  for (const entry of entries) {
+    if (entry === current) continue;
+    try {
+      await rm(join(storageRoot, entry), { recursive: true, force: true, maxRetries: 3, retryDelay: 250 });
+    } catch (err) {
+      // Best effort: a directory still locked by a lingering process is left
+      // for the next run rather than failing an otherwise green e2e suite.
+      console.warn(`e2e teardown: could not remove ${entry}:`, err);
+    }
+  }
 };


### PR DESCRIPTION
Follow-up to #45 (issue #30). Found by the final local verification on Windows after all 13 PRs were merged.

**Problem:** the `globalTeardown` added in #45 deleted `src/cs/Deucalion.Api/.e2e-storage` while the backend `webServer` was still alive. Linux can unlink an open SQLite file (so CI was green); Windows cannot — `EBUSY: resource busy or locked` turned a green 18/18 e2e run into exit code 1.

**Fix:** each run gets its own `./.e2e-storage/<run id>` (`DEUCALION__STORAGEPATH` in `playwright.config.ts`), and teardown removes every *other* run's directory, best-effort (retries, warns instead of failing). The live run's directory is cleaned by the next run, so nothing accumulates.

**Evidence (Windows, `CI=1`):** `npm run lint` clean; two consecutive `npm run test:e2e` runs → `18 passed`, exit 0 both times; exactly one storage directory left after each run (the previous one was removed).