### PR TITLE
feat(api): accurate since on /api/status; ?group= filter and /api/status/{name}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,10 @@ exception: long keys, string states, ISO-8601 timestamps. They exist for agents
 and humans on a one-shot fetch, the UI never reads them, and they are
 deliberately **not** mirrored in `deucalion-types.ts`. Their shape is pinned by
 the `Discovery` tests in `ApiIntegrationTests.cs`, and `public/llms.txt` must
-keep naming every endpoint (`DiscoveryHeadTests.cs` fails otherwise).
+keep naming every endpoint (`DiscoveryHeadTests.cs` fails otherwise). `MonitorRun`
+(`Deucalion.Core/Storage/MonitorRun.cs`, `IStorage.GetCurrentRunAsync`) is the
+storage-side sibling of those DTOs: it backs `since`/`sinceIsLowerBound` and is
+likewise not mirrored in TS.
 
 ## Engine invariants
 

--- a/README.md
+++ b/README.md
@@ -264,12 +264,14 @@ Everything the page shows is available as JSON, unauthenticated, with open CORS 
 
 | Endpoint | Returns |
 |----------|---------|
-| `GET /api/status` | Self-describing summary: overall `status` (`operational` -- nothing down; `degraded` -- some monitors down; `outage` -- every monitor down), `updatedAt`, overall `availability` (%), one entry per monitor (`name`, `group`, `type`, `state` as `up` / `warn` / `down` / `degraded` / `unknown`, `since`, `availability`, `latencyMs`), and `links` to the other endpoints. Timestamps are ISO-8601 UTC. Start here. |
+| `GET /api/status` | Self-describing summary: overall `status` (`operational` -- nothing down; `degraded` -- some monitors down; `outage` -- every monitor down), `updatedAt`, overall `availability` (%), one entry per monitor (`name`, `group`, `type`, `state` as `up` / `warn` / `down` / `degraded` / `unknown`, `since`, `sinceIsLowerBound`, `availability`, `latencyMs`), and `links` to the other endpoints. `since` is when the current run began -- "down since" or "up since" (`warn` and `degraded` count as up) -- computed from the whole stored history, not the 60-probe stats window; `sinceIsLowerBound: true` means the run reaches the oldest event still retained, so the monitor has been in that state *at least* since then. Timestamps are ISO-8601 UTC. Start here. |
+| `GET /api/status?group=<name>` | The same document restricted to one group (case-insensitive); `status` and `availability` are recomputed over that group and the response echoes `group`. An unknown group returns `404` `application/problem+json` whose `detail` lists the configured groups. |
+| `GET /api/status/{name}` | One monitor: `updatedAt`, `monitor` (the same shape as its entry in `/api/status`) and `links` (`self`, `status`, `monitor` = the full-detail document, `events`). Unknown names return `404` `application/problem+json`. |
 | `GET /` with `Accept: application/json` | The same document as `/api/status` (responses carry `Vary: Accept`; a browser's Accept header still gets the HTML). |
 | `GET /api/version` | `name`, `version` (build number and git SHA), `runtime`, `startedAt` -- tells you which build a deployment is actually running. |
 | `GET /api/monitors` | Full detail per monitor as the UI consumes it: `config`, rolling `stats` (last 60 probes), and the recent `events` in compact form (`at` unix seconds, `st` numeric state, `ms` latency). |
 | `GET /api/monitors/{name}` | One monitor in the same shape. Unknown names return `404` `application/problem+json`. |
-| `GET /api/monitors/events` | Server-Sent Events stream: `MonitorChecked` (`n`, `at`, `fr`, `st`, `ms`, `ns`) on every probe and `MonitorStateChanged` (`n`, `at`, `fr`, `st`) on transitions. |
+| `GET /api/monitors/events` | Server-Sent Events stream: `MonitorChecked` (`n`, `at`, `st`, `ms`, `ns`) on every probe and `MonitorStateChanged` (`n`, `at`, `st`) on transitions. |
 | `POST /api/monitors/{name}/checkin` | Heartbeat for `checkin` monitors -- see [`checkin` Monitor](#checkin-monitor). |
 | `GET /llms.txt` | Plain-Markdown description of the above, for agents that look for it. |
 

--- a/src/cs/Deucalion.Api/DeucalionJsonContext.cs
+++ b/src/cs/Deucalion.Api/DeucalionJsonContext.cs
@@ -22,6 +22,7 @@ namespace Deucalion.Api;
 [JsonSerializable(typeof(MonitorDto[]))]
 [JsonSerializable(typeof(PageConfigurationDto))]
 [JsonSerializable(typeof(StatusDto))]
+[JsonSerializable(typeof(MonitorStatusDto))]
 [JsonSerializable(typeof(VersionDto))]
 // ProblemDetails backs every Results.Problem(...) -- the 404 for unknown monitors, the check-in
 // errors and the exception handler. Under native AOT there is no reflection fallback resolver,

--- a/src/cs/Deucalion.Api/Endpoints/DiscoveryEndpoints.cs
+++ b/src/cs/Deucalion.Api/Endpoints/DiscoveryEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Deucalion.Api.Http;
 using Deucalion.Api.Models;
 using Deucalion.Application.Configuration;
 using Deucalion.Configuration;
@@ -9,25 +10,20 @@ using Deucalion.Storage;
 namespace Deucalion.Api.Endpoints;
 
 /// <summary>
-/// The agent-facing door into the API: a self-describing status summary and a version endpoint.
-/// Everything here is read-only over storage -- it never touches the monitor objects, so agent
-/// polling cannot race the engine.
+/// The agent-facing door into the API: a self-describing status summary (whole page, one group,
+/// or one monitor) and a version endpoint. Everything here is read-only over storage -- it never
+/// touches the monitor objects, so agent polling cannot race the engine.
 /// </summary>
 public static class DiscoveryEndpoints
 {
     public const string StatusPath = "/api/status";
+    public const string MonitorStatusPathTemplate = "/api/status/{name}";
     public const string VersionPath = "/api/version";
     public const string MonitorsPath = "/api/monitors";
     public const string EventsPath = "/api/monitors/events";
     public const string DocsPath = "/llms.txt";
 
-    private static readonly StatusLinksDto Links = new(
-        Self: StatusPath,
-        Monitors: MonitorsPath,
-        Events: EventsPath,
-        Version: VersionPath,
-        Docs: DocsPath
-    );
+    private const string GroupQueryParameter = "group";
 
     // Get version info from assembly -- https://stackoverflow.com/a/64793765/33244
     //   SourceRevisionId included since .NET 8 SDK -- https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link
@@ -45,14 +41,16 @@ public static class DiscoveryEndpoints
         _startedAt = timeProvider.GetUtcNow().UtcDateTime;
 
         app.MapGet(StatusPath, WriteStatusAsync);
+        app.MapGet("/api/status/{monitorName}", WriteMonitorStatusAsync);
         app.MapGet(VersionPath, WriteVersionAsync);
 
         return app;
     }
 
     /// <summary>
-    /// Writes the <c>/api/status</c> payload to <paramref name="context"/>. Public so the
-    /// service host can serve the same document for <c>GET /</c> with <c>Accept: application/json</c>.
+    /// Writes the <c>/api/status</c> payload to <paramref name="context"/>, honouring an optional
+    /// <c>?group=</c> filter. Public so the service host can serve the same document for
+    /// <c>GET /</c> with <c>Accept: application/json</c>.
     /// </summary>
     public static async Task WriteStatusAsync(HttpContext context)
     {
@@ -60,8 +58,44 @@ public static class DiscoveryEndpoints
         var configuration = context.RequestServices.GetRequiredService<ApplicationConfiguration>();
         var timeProvider = context.RequestServices.GetRequiredService<TimeProvider>();
 
-        var status = await BuildStatusAsync(storage, configuration, timeProvider, context.RequestAborted);
+        var group = context.Request.Query.TryGetValue(GroupQueryParameter, out var values) ? values.ToString() : null;
+
+        var status = await BuildStatusAsync(storage, configuration, timeProvider, group, context.RequestAborted);
+        if (status is null)
+        {
+            await DeucalionResults.GroupNotFound(group!, KnownGroups(configuration)).ExecuteAsync(context);
+            return;
+        }
+
         await Results.Json(status, DeucalionJsonContext.Default.StatusDto).ExecuteAsync(context);
+    }
+
+    private static async Task WriteMonitorStatusAsync(HttpContext context, string monitorName)
+    {
+        var storage = context.RequestServices.GetRequiredService<IStorage>();
+        var configuration = context.RequestServices.GetRequiredService<ApplicationConfiguration>();
+        var timeProvider = context.RequestServices.GetRequiredService<TimeProvider>();
+
+        if (!configuration.Monitors.TryGetValue(monitorName, out var monitorConfiguration))
+        {
+            await DeucalionResults.MonitorNotFound(monitorName).ExecuteAsync(context);
+            return;
+        }
+
+        var monitor = await BuildMonitorAsync(storage, monitorName, monitorConfiguration, context.RequestAborted);
+        var escapedName = Uri.EscapeDataString(monitorName);
+        var payload = new MonitorStatusDto(
+            UpdatedAt: timeProvider.GetUtcNow().UtcDateTime,
+            Monitor: monitor,
+            Links: new MonitorStatusLinksDto(
+                Self: $"{StatusPath}/{escapedName}",
+                Status: StatusPath,
+                Monitor: $"{MonitorsPath}/{escapedName}",
+                Events: EventsPath
+            )
+        );
+
+        await Results.Json(payload, DeucalionJsonContext.Default.MonitorStatusDto).ExecuteAsync(context);
     }
 
     private static Task WriteVersionAsync(HttpContext context)
@@ -75,9 +109,18 @@ public static class DiscoveryEndpoints
         return Results.Json(version, DeucalionJsonContext.Default.VersionDto).ExecuteAsync(context);
     }
 
-    internal static async Task<StatusDto> BuildStatusAsync(IStorage storage, ApplicationConfiguration configuration, TimeProvider timeProvider, CancellationToken cancellationToken)
+    /// <returns>The summary, or null when <paramref name="group"/> is set but matches no monitor.</returns>
+    internal static async Task<StatusDto?> BuildStatusAsync(IStorage storage, ApplicationConfiguration configuration, TimeProvider timeProvider, string? group, CancellationToken cancellationToken)
     {
-        var monitors = await Task.WhenAll(configuration.Monitors.Select(kvp => BuildMonitorAsync(storage, kvp.Key, kvp.Value, cancellationToken)));
+        var selected = group is null
+            ? configuration.Monitors.AsEnumerable()
+            : configuration.Monitors.Where(kvp => string.Equals(kvp.Value.Group, group, StringComparison.OrdinalIgnoreCase));
+
+        var monitors = await Task.WhenAll(selected.Select(kvp => BuildMonitorAsync(storage, kvp.Key, kvp.Value, cancellationToken)));
+        if (group is not null && monitors.Length == 0)
+        {
+            return null;
+        }
 
         // Monitors that have never been probed do not vote: with no evidence either way they
         // must neither drag the summary into "degraded" nor mask a real outage.
@@ -94,41 +137,46 @@ public static class DiscoveryEndpoints
 
         return new StatusDto(
             Status: status,
+            Group: group,
             UpdatedAt: timeProvider.GetUtcNow().UtcDateTime,
             Availability: availabilities.Length > 0 ? Math.Round(availabilities.Average(), 2) : null,
             Monitors: monitors,
-            Links: Links
+            Links: new StatusLinksDto(
+                Self: group is null ? StatusPath : $"{StatusPath}?{GroupQueryParameter}={Uri.EscapeDataString(group)}",
+                Monitors: MonitorsPath,
+                MonitorStatus: MonitorStatusPathTemplate,
+                Events: EventsPath,
+                Version: VersionPath,
+                Docs: DocsPath
+            )
         );
     }
+
+    internal static IEnumerable<string> KnownGroups(ApplicationConfiguration configuration) =>
+        configuration.Monitors.Values
+            .Select(m => m.Group)
+            .Where(g => !string.IsNullOrWhiteSpace(g))
+            .Distinct(StringComparer.OrdinalIgnoreCase)!;
 
     private static async Task<StatusMonitorDto> BuildMonitorAsync(IStorage storage, string name, PullMonitorConfiguration configuration, CancellationToken cancellationToken)
     {
         // Same rolling window as /api/monitors, so the two endpoints agree on availability.
         var stats = await storage.GetStatsAsync(name, historyCount: PullMonitor.StatsWindow, cancellationToken: cancellationToken);
-        var events = (await storage.GetLastEventsAsync(name, count: PullMonitor.StatsWindow, cancellationToken: cancellationToken)).ToArray();
-
         var state = stats?.LastState ?? MonitorState.Unknown;
 
-        // `since`: the oldest event of the trailing run in the current state. Bounded by the
-        // window, so a long-stable monitor reports "at least since".
-        DateTime? since = null;
-        int? latencyMs = null;
-        if (events.Length > 0)
-        {
-            // Newest first.
-            latencyMs = (int?)events[0].ResponseTime?.TotalMilliseconds;
-            var run = events.TakeWhile(e => e.State == state).ToArray();
-            since = run.Length > 0 ? run[^1].At.UtcDateTime : null;
-        }
+        // `since` comes from the current run in storage, not from the stats window: a monitor
+        // down for three days must say so, not "since the 60th-newest probe".
+        var run = state == MonitorState.Unknown ? null : await storage.GetCurrentRunAsync(name, cancellationToken);
 
         return new StatusMonitorDto(
             Name: name,
             Group: configuration.Group,
             Type: MonitorConfigurationDto.From(configuration).Type,
             State: StateName(state),
-            Since: since,
+            Since: run?.Since.UtcDateTime,
+            SinceIsLowerBound: run?.SinceIsLowerBound,
             Availability: stats is null ? null : Math.Round(stats.Availability, 2),
-            LatencyMs: latencyMs
+            LatencyMs: (int?)run?.LastResponseTime?.TotalMilliseconds
         );
     }
 

--- a/src/cs/Deucalion.Api/Http/DeucalionResults.cs
+++ b/src/cs/Deucalion.Api/Http/DeucalionResults.cs
@@ -8,6 +8,10 @@ internal static class DeucalionResults
         Problem("monitor-not-found", "Monitor not found.", HttpStatusCode.NotFound,
             $"Monitor '{monitorName}' not found.");
 
+    internal static IResult GroupNotFound(string group, IEnumerable<string> knownGroups) =>
+        Problem("group-not-found", "Group not found.", HttpStatusCode.NotFound,
+            $"Group '{group}' not found. Configured groups: {string.Join(", ", knownGroups.Select(g => $"'{g}'"))}.");
+
     internal static IResult NotCheckInMonitor(string monitorName, string instanceUri) =>
         Problem("not-checkin-monitor", "Not a check-in monitor.", HttpStatusCode.BadRequest,
             $"'{monitorName}' is not a check-in monitor.", instanceUri);

--- a/src/cs/Deucalion.Api/Models/StatusDto.cs
+++ b/src/cs/Deucalion.Api/Models/StatusDto.cs
@@ -6,28 +6,56 @@ namespace Deucalion.Api.Models;
 /// this payload is for agents and humans on a one-shot discovery fetch, not for the UI, so it
 /// is NOT mirrored in <c>deucalion-types.ts</c>.
 /// </summary>
+/// <param name="Group">Echoes the <c>?group=</c> filter; absent for the unfiltered document.</param>
 public record StatusDto(
     string Status,
+    string? Group,
     DateTime UpdatedAt,
     double? Availability,
     StatusMonitorDto[] Monitors,
     StatusLinksDto Links
 );
 
+/// <param name="Since">
+/// When the current run started: "down since" or "up since" (Warn and Degraded count as up).
+/// Bounded only by event retention -- see <paramref name="SinceIsLowerBound"/>.
+/// </param>
+/// <param name="SinceIsLowerBound">
+/// True when the run reaches the oldest stored event, so the monitor has been in this state
+/// <em>at least</em> since <paramref name="Since"/>. Absent when <paramref name="Since"/> is.
+/// </param>
 public record StatusMonitorDto(
     string Name,
     string? Group,
     string Type,
     string State,
     DateTime? Since,
+    bool? SinceIsLowerBound,
     double? Availability,
     int? LatencyMs
 );
 
+/// <param name="MonitorStatus">Template for the per-monitor document, e.g. <c>/api/status/{name}</c>.</param>
 public record StatusLinksDto(
     string Self,
     string Monitors,
+    string MonitorStatus,
     string Events,
     string Version,
     string Docs
+);
+
+/// <summary>Served by <c>GET /api/status/{name}</c>: one monitor, same shape as its entry in <see cref="StatusDto"/>.</summary>
+public record MonitorStatusDto(
+    DateTime UpdatedAt,
+    StatusMonitorDto Monitor,
+    MonitorStatusLinksDto Links
+);
+
+/// <param name="Monitor">The full-detail document for this monitor (<c>/api/monitors/{name}</c>).</param>
+public record MonitorStatusLinksDto(
+    string Self,
+    string Status,
+    string Monitor,
+    string Events
 );

--- a/src/cs/Deucalion.Core/Storage/IStorage.cs
+++ b/src/cs/Deucalion.Core/Storage/IStorage.cs
@@ -8,6 +8,12 @@ public interface IStorage
 
     Task<IEnumerable<StoredEvent>> GetLastEventsAsync(string monitorName, int count = 60, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// The monitor's current run (see <see cref="MonitorRun"/>), or null when it has no non-Unknown
+    /// events. One indexed query regardless of how long the run is.
+    /// </summary>
+    Task<MonitorRun?> GetCurrentRunAsync(string monitorName, CancellationToken cancellationToken = default);
+
     Task SaveEventAsync(string monitorName, StoredEvent storedEvent, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/cs/Deucalion.Core/Storage/MonitorRun.cs
+++ b/src/cs/Deucalion.Core/Storage/MonitorRun.cs
@@ -1,0 +1,24 @@
+namespace Deucalion.Storage;
+
+/// <summary>
+/// A monitor's current run, for the discovery payload (`/api/status`): "down since" / "up since".
+/// A run is a maximal sequence of events on the same side of the down/available divide --
+/// <see cref="MonitorState.Down"/> on one side, <see cref="MonitorState.Up"/>,
+/// <see cref="MonitorState.Warn"/> and <see cref="MonitorState.Degraded"/> on the other, so a
+/// Warn blip does not reset "up since". <see cref="MonitorState.Unknown"/> events neither start
+/// nor end a run.
+/// </summary>
+/// <param name="State">The newest non-Unknown state.</param>
+/// <param name="Since">When the run started: the first stored event after the newest event of the other kind.</param>
+/// <param name="SinceIsLowerBound">
+/// True when no event of the other kind is stored at all, i.e. the run reaches the oldest row
+/// still retained (see <c>EventRetentionPeriod</c> / <c>MaxEventsPerMonitor</c>): the monitor
+/// has been in this state <em>at least</em> since <paramref name="Since"/>.
+/// </param>
+/// <param name="LastResponseTime">The newest probe's response time, if it recorded one.</param>
+public record MonitorRun(
+    MonitorState State,
+    DateTimeOffset Since,
+    bool SinceIsLowerBound,
+    TimeSpan? LastResponseTime
+);

--- a/src/cs/Deucalion.Storage/SqliteStorage.cs
+++ b/src/cs/Deucalion.Storage/SqliteStorage.cs
@@ -220,6 +220,56 @@ public sealed class SqliteStorage : IStorage, IDisposable
         return results;
     }
 
+    public async Task<MonitorRun?> GetCurrentRunAsync(string monitorName, CancellationToken cancellationToken = default)
+    {
+        using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync(cancellationToken);
+
+        // Runs are split by the down/available divide (Down vs Up/Warn/Degraded); Unknown rows are
+        // ignored throughout. `Boundary` is the newest event of the *other* kind; the run starts at
+        // the first event after it. No boundary at all means the run reaches the oldest stored row,
+        // so `Since` is only a lower bound. Every subquery walks the (MonitorName, TimestampTicks)
+        // primary key, so the cost does not grow with the length of the run.
+        using var command = connection.CreateCommand();
+        command.CommandText = $"""
+            WITH Newest AS (
+                SELECT State, ResponseTimeTicks
+                FROM {EventsTableName}
+                WHERE MonitorName = @MonitorName AND State <> {(int)MonitorState.Unknown}
+                ORDER BY TimestampTicks DESC
+                LIMIT 1
+            ),
+            Boundary AS (
+                SELECT MAX(TimestampTicks) AS T
+                FROM {EventsTableName}
+                WHERE MonitorName = @MonitorName AND State <> {(int)MonitorState.Unknown}
+                  AND (State = {(int)MonitorState.Down}) <> ((SELECT State FROM Newest) = {(int)MonitorState.Down})
+            )
+            SELECT
+                (SELECT State FROM Newest) AS State,
+                (SELECT ResponseTimeTicks FROM Newest) AS ResponseTimeTicks,
+                (SELECT MIN(TimestampTicks)
+                   FROM {EventsTableName}
+                  WHERE MonitorName = @MonitorName AND State <> {(int)MonitorState.Unknown}
+                    AND TimestampTicks > COALESCE((SELECT T FROM Boundary), -1)) AS SinceTicks,
+                (SELECT T FROM Boundary) IS NULL AS SinceIsLowerBound;
+            """;
+        command.Parameters.AddWithValue("@MonitorName", monitorName);
+
+        using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        if (!await reader.ReadAsync(cancellationToken) || reader.IsDBNull(0))
+        {
+            return null;
+        }
+
+        return new MonitorRun(
+            State: (MonitorState)reader.GetInt64(0),
+            Since: new DateTimeOffset(reader.GetInt64(2), TimeSpan.Zero),
+            SinceIsLowerBound: reader.GetInt64(3) == 1,
+            LastResponseTime: reader.IsDBNull(1) ? null : new TimeSpan(reader.GetInt64(1))
+        );
+    }
+
     public async Task SaveEventAsync(string monitorName, StoredEvent storedEvent, CancellationToken cancellationToken = default)
     {
         // Create connection per operation

--- a/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
+++ b/src/cs/Deucalion.Tests/Api/ApiIntegrationTests.cs
@@ -52,7 +52,7 @@ public sealed class ApiIntegrationTests : IAsyncLifetime
             monitors:
               web-main: !http
                 url: https://example.com
-                group: Main
+                group: Web
 
               checkin-main: !checkin
                 secret: test-secret
@@ -634,6 +634,142 @@ public sealed class ApiIntegrationTests : IAsyncLifetime
 
         var after = monitors.Values.Select(m => (m.Name, m.AutoWarnTimeout, m.WarnTimeout)).ToArray();
         Assert.Equal(before, after);
+    }
+
+    [Fact]
+    public async Task GetStatus_Since_IsTheStartOfTheRun_NotTheStatsWindow()
+    {
+        // Regression: `since` used to be derived from the last 60 events, so a monitor down for
+        // longer than the stats window reported "down since the 60th-newest probe".
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var start = DateTimeOffset.UtcNow.AddMinutes(-200);
+
+        await storage.SaveEventAsync("web-main", new StoredEvent(start, MonitorState.Up, TimeSpan.FromMilliseconds(30), null), TestContext.Current.CancellationToken);
+        for (var i = 1; i <= 100; i++)
+        {
+            await storage.SaveEventAsync("web-main", new StoredEvent(start.AddMinutes(i), MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        }
+
+        using var client = _factory.CreateClient();
+        var payload = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+        var web = payload.GetProperty("monitors").EnumerateArray().Single(m => m.GetProperty("name").GetString() == "web-main");
+
+        Assert.Equal("down", web.GetProperty("state").GetString());
+        Assert.Equal(start.AddMinutes(1).UtcDateTime, DateTime.Parse(web.GetProperty("since").GetString()!, null, System.Globalization.DateTimeStyles.AdjustToUniversal), TimeSpan.FromMilliseconds(1));
+        Assert.False(web.GetProperty("sinceIsLowerBound").GetBoolean(), "an Up probe precedes the run, so `since` is exact");
+    }
+
+    [Fact]
+    public async Task GetStatus_SinceIsLowerBound_WhenTheRunReachesTheOldestEvent()
+    {
+        // The engine probes every monitor once at host start; a check-in monitor that nobody has
+        // checked in to is Down from that first probe. Extending that Down run means no event of
+        // the other kind exists at all, so `since` can only be a lower bound.
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        await storage.SaveEventAsync("checkin-open", new StoredEvent(now, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-open", new StoredEvent(now.AddSeconds(1), MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+
+        using var client = _factory.CreateClient();
+        var payload = await client.GetFromJsonAsync<JsonElement>("/api/status/checkin-open", TestContext.Current.CancellationToken);
+        var monitor = payload.GetProperty("monitor");
+
+        Assert.Equal("down", monitor.GetProperty("state").GetString());
+        var since = DateTime.Parse(monitor.GetProperty("since").GetString()!, null, System.Globalization.DateTimeStyles.AdjustToUniversal);
+        Assert.True(since <= now.UtcDateTime, "the run starts at the engine's startup probe, before the seeded events");
+        Assert.True(monitor.GetProperty("sinceIsLowerBound").GetBoolean());
+        Assert.False(monitor.TryGetProperty("latencyMs", out _), "a failed probe has no latency; the key must be omitted");
+    }
+
+    [Fact]
+    public async Task GetStatus_GroupFilter_RestrictsMonitorsAndRecomputesTheSummary()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        // Web is down, Main is up: the whole page is "degraded", the Main group is "operational".
+        await storage.SaveEventAsync("web-main", new StoredEvent(now, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now, MonitorState.Up, TimeSpan.FromMilliseconds(5), null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-open", new StoredEvent(now, MonitorState.Up, TimeSpan.FromMilliseconds(5), null), TestContext.Current.CancellationToken);
+
+        using var client = _factory.CreateClient();
+        var whole = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+        Assert.Equal("degraded", whole.GetProperty("status").GetString());
+        Assert.False(whole.TryGetProperty("group", out _));
+
+        // Case-insensitive match; the response echoes the filter and links to itself.
+        var main = await client.GetFromJsonAsync<JsonElement>("/api/status?group=main", TestContext.Current.CancellationToken);
+        Assert.Equal("operational", main.GetProperty("status").GetString());
+        Assert.Equal("main", main.GetProperty("group").GetString());
+        Assert.Equal(["checkin-main", "checkin-open"], main.GetProperty("monitors").EnumerateArray().Select(m => m.GetProperty("name").GetString()));
+        // Recomputed over the group only: the Web monitor (0 % after its Down) no longer drags it.
+        Assert.True(main.GetProperty("availability").GetDouble() > whole.GetProperty("availability").GetDouble());
+        Assert.Equal("/api/status?group=main", main.GetProperty("links").GetProperty("self").GetString());
+        Assert.Equal("/api/status/{name}", main.GetProperty("links").GetProperty("monitorStatus").GetString());
+
+        var web = await client.GetFromJsonAsync<JsonElement>("/api/status?group=Web", TestContext.Current.CancellationToken);
+        Assert.Equal("outage", web.GetProperty("status").GetString());
+        Assert.Single(web.GetProperty("monitors").EnumerateArray());
+    }
+
+    [Fact]
+    public async Task GetStatus_UnknownGroup_Returns404ProblemListingTheGroups()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/status?group=nope", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        Assert.Equal("/api/errors/group-not-found", problem.GetProperty("type").GetString());
+        var detail = problem.GetProperty("detail").GetString()!;
+        Assert.Contains("'nope'", detail, StringComparison.Ordinal);
+        Assert.Contains("'Web'", detail, StringComparison.Ordinal);
+        Assert.Contains("'Main'", detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetMonitorStatus_MirrorsTheEntryInTheFullDocument()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IStorage>();
+        var now = DateTimeOffset.UtcNow.AddSeconds(1);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        await storage.SaveEventAsync("checkin-main", new StoredEvent(now.AddSeconds(1), MonitorState.Up, TimeSpan.FromMilliseconds(42), null), TestContext.Current.CancellationToken);
+
+        using var client = _factory.CreateClient();
+        var whole = await client.GetFromJsonAsync<JsonElement>("/api/status", TestContext.Current.CancellationToken);
+        var entry = whole.GetProperty("monitors").EnumerateArray().Single(m => m.GetProperty("name").GetString() == "checkin-main");
+
+        using var response = await client.GetAsync("/api/status/checkin-main", TestContext.Current.CancellationToken);
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        var single = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+
+        Assert.Equal(entry.GetRawText(), single.GetProperty("monitor").GetRawText());
+        Assert.True(DateTimeOffset.TryParse(single.GetProperty("updatedAt").GetString(), out _));
+        var links = single.GetProperty("links");
+        Assert.Equal("/api/status/checkin-main", links.GetProperty("self").GetString());
+        Assert.Equal("/api/status", links.GetProperty("status").GetString());
+        Assert.Equal("/api/monitors/checkin-main", links.GetProperty("monitor").GetString());
+        Assert.Equal("/api/monitors/events", links.GetProperty("events").GetString());
+    }
+
+    [Fact]
+    public async Task GetMonitorStatus_UnknownMonitor_Returns404Problem()
+    {
+        using var client = _factory.CreateClient();
+
+        using var response = await client.GetAsync("/api/status/does-not-exist", TestContext.Current.CancellationToken);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var problem = await response.Content.ReadFromJsonAsync<JsonElement>(TestContext.Current.CancellationToken);
+        Assert.Equal("/api/errors/monitor-not-found", problem.GetProperty("type").GetString());
     }
 
     [Fact]

--- a/src/cs/Deucalion.Tests/Api/DiscoveryEndpointsTests.cs
+++ b/src/cs/Deucalion.Tests/Api/DiscoveryEndpointsTests.cs
@@ -1,0 +1,69 @@
+using Deucalion.Api.Endpoints;
+using Deucalion.Application.Configuration;
+using Deucalion.Storage;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Deucalion.Tests.Api;
+
+/// <summary>
+/// The parts of <see cref="DiscoveryEndpoints"/> that the integration suite cannot observe: the
+/// engine probes every monitor once at host start there, so a never-probed monitor only exists
+/// against a storage double.
+/// </summary>
+public class DiscoveryEndpointsTests
+{
+    private static readonly ApplicationConfiguration Configuration = ApplicationConfiguration.ReadFromString(
+        """
+        monitors:
+          alpha: !checkin
+            group: A
+          beta: !checkin
+            group: B
+        """);
+
+    [Fact]
+    public async Task NeverProbedMonitor_IsUnknown_WithoutSince_AndWithoutQueryingTheRun()
+    {
+        var storage = new EmptyStorage();
+
+        var status = await DiscoveryEndpoints.BuildStatusAsync(storage, Configuration, new FakeTimeProvider(), group: null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(status);
+        Assert.Equal("operational", status.Status); // nothing known to be down
+        Assert.Null(status.Availability);
+        Assert.All(status.Monitors, m =>
+        {
+            Assert.Equal("unknown", m.State);
+            Assert.Null(m.Since);
+            Assert.Null(m.SinceIsLowerBound);
+            Assert.Null(m.LatencyMs);
+        });
+        Assert.Equal(0, storage.RunQueries);
+    }
+
+    [Fact]
+    public async Task GroupFilter_UnknownGroup_YieldsNull_AndKnownGroupsAreListed()
+    {
+        var status = await DiscoveryEndpoints.BuildStatusAsync(new EmptyStorage(), Configuration, new FakeTimeProvider(), group: "nope", TestContext.Current.CancellationToken);
+
+        Assert.Null(status);
+        Assert.Equal(["A", "B"], DiscoveryEndpoints.KnownGroups(Configuration));
+    }
+
+    private sealed class EmptyStorage : IStorage
+    {
+        public int RunQueries { get; private set; }
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<MonitorStats?> GetStatsAsync(string monitorName, int historyCount = 60, CancellationToken cancellationToken = default) => Task.FromResult<MonitorStats?>(null);
+        public Task<IEnumerable<StoredEvent>> GetLastEventsAsync(string monitorName, int count = 60, CancellationToken cancellationToken = default) => Task.FromResult(Enumerable.Empty<StoredEvent>());
+        public Task<MonitorRun?> GetCurrentRunAsync(string monitorName, CancellationToken cancellationToken = default)
+        {
+            RunQueries++;
+            return Task.FromResult<MonitorRun?>(null);
+        }
+        public Task SaveEventAsync(string monitorName, StoredEvent storedEvent, CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task<int> PurgeOldEventsAsync(TimeSpan retentionPeriod, int maxEventsPerMonitor, CancellationToken cancellationToken = default) => Task.FromResult(0);
+    }
+}

--- a/src/cs/Deucalion.Tests/Api/PurgeBackgroundServiceTests.cs
+++ b/src/cs/Deucalion.Tests/Api/PurgeBackgroundServiceTests.cs
@@ -44,6 +44,7 @@ public class PurgeBackgroundServiceTests
 
         public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
         public Task<MonitorStats?> GetStatsAsync(string monitorName, int historyCount = 60, CancellationToken cancellationToken = default) => Task.FromResult<MonitorStats?>(null);
+        public Task<MonitorRun?> GetCurrentRunAsync(string monitorName, CancellationToken cancellationToken = default) => Task.FromResult<MonitorRun?>(null);
         public Task<IEnumerable<StoredEvent>> GetLastEventsAsync(string monitorName, int count = 60, CancellationToken cancellationToken = default) => Task.FromResult<IEnumerable<StoredEvent>>([]);
         public Task SaveEventAsync(string monitorName, StoredEvent storedEvent, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }

--- a/src/cs/Deucalion.Tests/Service/DiscoveryHeadTests.cs
+++ b/src/cs/Deucalion.Tests/Service/DiscoveryHeadTests.cs
@@ -213,13 +213,13 @@ public sealed class DiscoveryHeadTests : IAsyncLifetime
         Assert.Equal("text/plain", response.Content.Headers.ContentType?.MediaType);
 
         var text = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
-        foreach (var path in new[] { "/api/status", "/api/monitors", "/api/monitors/{name}", "/api/monitors/events", "/api/version", "/api/monitors/{name}/checkin" })
+        foreach (var path in new[] { "/api/status", "/api/status?group=", "/api/status/{name}", "/api/monitors", "/api/monitors/{name}", "/api/monitors/events", "/api/version", "/api/monitors/{name}/checkin" })
         {
             Assert.Contains(path, text, StringComparison.Ordinal);
         }
 
         // The SSE short keys, as documented for agents.
-        foreach (var key in new[] { "\"n\"", "\"at\"", "\"fr\"", "\"st\"", "\"ms\"", "\"ns\"" })
+        foreach (var key in new[] { "\"n\"", "\"at\"", "\"st\"", "\"ms\"", "\"ns\"" })
         {
             Assert.Contains(key, text, StringComparison.Ordinal);
         }

--- a/src/cs/Deucalion.Tests/Storage/SqliteStorageRunTests.cs
+++ b/src/cs/Deucalion.Tests/Storage/SqliteStorageRunTests.cs
@@ -1,0 +1,114 @@
+using Deucalion.Storage;
+using Xunit;
+
+namespace Deucalion.Tests.Storage;
+
+/// <summary>
+/// <see cref="SqliteStorage.GetCurrentRunAsync"/> backs the "down since" / "up since" of
+/// <c>/api/status</c>. It used to be derived from the last 60 events, so anything longer than an
+/// hour at the default interval was reported as "since an hour ago".
+/// </summary>
+public class SqliteStorageRunTests : SqliteStorageTestBase
+{
+    private const string Monitor = "run-test";
+    private static readonly DateTimeOffset T0 = new(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly TimeSpan Step = TimeSpan.FromSeconds(60);
+
+    private async Task SaveAsync(int index, MonitorState state, int? ms = null)
+    {
+        var ev = new StoredEvent(T0 + Step * index, state, ms is null ? null : TimeSpan.FromMilliseconds(ms.Value), null);
+        await Storage.SaveEventAsync(Monitor, ev, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task ThreeDaysDown_SinceIsTheFirstDownProbe_NotTheStatsWindow()
+    {
+        await SaveAsync(0, MonitorState.Up, 10);
+        const int downProbes = 3 * 24 * 60; // 4,320 -- far more than the 60-event stats window
+        for (var i = 1; i <= downProbes; i++)
+        {
+            await SaveAsync(i, MonitorState.Down);
+        }
+
+        var run = await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(run);
+        Assert.Equal(MonitorState.Down, run.State);
+        Assert.Equal(T0 + Step, run.Since);
+        Assert.False(run.SinceIsLowerBound);
+        Assert.Null(run.LastResponseTime);
+    }
+
+    [Fact]
+    public async Task WarnDoesNotSplitAnUpRun()
+    {
+        await SaveAsync(0, MonitorState.Down);
+        await SaveAsync(1, MonitorState.Up, 10);
+        await SaveAsync(2, MonitorState.Warn, 900);
+        await SaveAsync(3, MonitorState.Degraded, 20);
+        await SaveAsync(4, MonitorState.Up, 12);
+
+        var run = await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(run);
+        Assert.Equal(MonitorState.Up, run.State);
+        Assert.Equal(T0 + Step * 1, run.Since);
+        Assert.False(run.SinceIsLowerBound);
+        Assert.Equal(TimeSpan.FromMilliseconds(12), run.LastResponseTime);
+    }
+
+    [Fact]
+    public async Task RunReachingTheOldestRow_IsOnlyALowerBound()
+    {
+        await SaveAsync(0, MonitorState.Down);
+        await SaveAsync(1, MonitorState.Down);
+        await SaveAsync(2, MonitorState.Down);
+
+        var run = await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(run);
+        Assert.Equal(MonitorState.Down, run.State);
+        Assert.Equal(T0, run.Since);
+        Assert.True(run.SinceIsLowerBound, "no event of the other kind is stored, so the run may predate retention");
+    }
+
+    [Fact]
+    public async Task UnknownRowsNeitherStartNorEndARun()
+    {
+        await SaveAsync(0, MonitorState.Down);
+        await SaveAsync(1, MonitorState.Unknown);
+        await SaveAsync(2, MonitorState.Up, 10);
+        await SaveAsync(3, MonitorState.Unknown);
+        await SaveAsync(4, MonitorState.Up, 11);
+
+        var run = await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(run);
+        Assert.Equal(MonitorState.Up, run.State);
+        Assert.Equal(T0 + Step * 2, run.Since);
+        Assert.False(run.SinceIsLowerBound);
+    }
+
+    [Fact]
+    public async Task NoEvents_ReturnsNull()
+    {
+        Assert.Null(await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken));
+
+        await SaveAsync(0, MonitorState.Unknown);
+        Assert.Null(await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task OtherMonitorsDoNotLeakIntoTheRun()
+    {
+        await Storage.SaveEventAsync("other", new StoredEvent(T0 + Step * 5, MonitorState.Down, null, null), TestContext.Current.CancellationToken);
+        await SaveAsync(0, MonitorState.Up, 10);
+        await SaveAsync(1, MonitorState.Up, 10);
+
+        var run = await Storage.GetCurrentRunAsync(Monitor, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(run);
+        Assert.Equal(T0, run.Since);
+        Assert.True(run.SinceIsLowerBound);
+    }
+}

--- a/src/ts/deucalion-ui/public/llms.txt
+++ b/src/ts/deucalion-ui/public/llms.txt
@@ -4,11 +4,13 @@
 
 ## Endpoints (all GET, all JSON)
 
-- `/api/status` — self-describing summary: `status` (`operational` | `degraded` | `outage`), `updatedAt` (ISO-8601 UTC), `availability` (%), and `monitors[]` with `name`, `group`, `type`, `state` (`up` | `warn` | `down` | `degraded` | `unknown`), `since`, `availability`, `latencyMs`. Start here. `GET /` with `Accept: application/json` returns the same document.
+- `/api/status` — self-describing summary: `status` (`operational` | `degraded` | `outage`), `updatedAt` (ISO-8601 UTC), `availability` (%), and `monitors[]` with `name`, `group`, `type`, `state` (`up` | `warn` | `down` | `degraded` | `unknown`), `since` (when the current run began: "down since" or "up since" — `warn` counts as up), `sinceIsLowerBound` (`true` when the run reaches the oldest stored event, i.e. "at least since"), `availability`, `latencyMs`. Start here. `GET /` with `Accept: application/json` returns the same document.
+- `/api/status?group=<name>` — the same document restricted to one group (case-insensitive); `status` and `availability` are recomputed over that group. Unknown group: 404 `application/problem+json` listing the configured groups.
+- `/api/status/{name}` — one monitor: `updatedAt`, `monitor` (same shape as an entry above) and `links`. Unknown name: 404 `application/problem+json`.
 - `/api/monitors` — full detail per monitor: `config`, rolling `stats`, and the recent `events[]` in the compact form `{ "at": <unix seconds>, "st": <state>, "ms": <latency> }` where `st` is 0 unknown, 1 down, 2 up, 3 warn, 4 degraded.
 - `/api/monitors/{name}` — one monitor in the same shape; unknown names return 404 `application/problem+json`.
 - `/api/version` — `name`, `version` (build + git SHA), `runtime`, `startedAt`.
-- `/api/monitors/events` — Server-Sent Events stream. Event `MonitorChecked`: `{ "n": name, "at": unix seconds, "fr": previous state, "st": state, "ms": latency, "ns": new stats }`. Event `MonitorStateChanged`: `{ "n", "at", "fr", "st" }`. Opens with a `: connected` comment.
+- `/api/monitors/events` — Server-Sent Events stream. Event `MonitorChecked`: `{ "n": name, "at": unix seconds, "st": state, "ms": latency, "ns": new stats }`. Event `MonitorStateChanged`: `{ "n", "at", "st" }`. Opens with a `: connected` comment.
 
 ## Writes
 


### PR DESCRIPTION
## Accurate `since`

`since` on `/api/status` was derived from the last 60 events (the stats window), so any run longer than ~1 hour at the default interval reported "since the 60th-newest probe", and a `Warn` blip reset "up since".

- New `IStorage.GetCurrentRunAsync` / `MonitorRun`: one indexed query over `(MonitorName, TimestampTicks)` returning the newest non-Unknown state, the first event after the newest event of the *other* kind (Down vs Up/Warn/Degraded), whether no such boundary exists (the run reaches the oldest retained row), and the newest response time. Cost does not grow with the run length.
- `/api/status` uses it: `since` is exact within retention; `"sinceIsLowerBound": true` says the monitor has been in this state *at least* since then. `latencyMs` now comes from the same query (one fewer query per monitor).

**Fail-before proof:** with the old logic patched back in, `GetStatus_Since_IsTheStartOfTheRun_NotTheStatsWindow` (100 Down probes after an Up) fails with `since` off by exactly 40 minutes — the 40 probes beyond the window.

## Cheaper agent queries

- `GET /api/status?group=<name>` — same document restricted to one group (case-insensitive); `status`/`availability` recomputed over it; response echoes `group`; `links.self` is the filtered URL. Unknown group → `404` `application/problem+json` (`group-not-found`) whose `detail` lists the configured groups.
- `GET /api/status/{name}` — `{ updatedAt, monitor, links }` with the monitor in the same shape as its entry in `/api/status`. Unknown name → the existing `monitor-not-found` 404.
- `links.monitorStatus` advertises the template `/api/status/{name}`.

Read-only over storage throughout; the engine invariant in CLAUDE.md holds (`GetStatus_IsReadOnly_DoesNotMutateMonitors` still passes).

## Docs

README API table, `llms.txt` (also drops the stale `fr` key that #45 removed — `DiscoveryHeadTests` was still asserting it), CLAUDE.md.

## Evidence

- `dotnet build -c Release`: 0 warnings. `dotnet test -c Release -- --minimum-expected-tests 101`: **245 passed, 8 network-skipped, 0 failed** (+6 `SqliteStorageRunTests`, +6 integration, +2 `DiscoveryEndpointsTests`).
- AOT binary (`Invoke-Build`, `deucalion-sample.yaml`): `?group=Google` → 3 monitors, `operational`; `/api/status/http-goog` → per-monitor document with links; `?group=nope` → 404 listing the five groups; `/api/status/nope` → 404 `monitor-not-found`; `GET /` with `Accept: application/json` unchanged (10 monitors, no `group` key).